### PR TITLE
pdf와 stroke 분리 / load시 stroke 배열화 / addPage page값 에러 수정

### DIFF
--- a/src/GridaBoard/GridaDoc.ts
+++ b/src/GridaBoard/GridaDoc.ts
@@ -171,7 +171,6 @@ export default class GridaDoc {
         const { url, filename, fingerprint, numPages } = pdfDoc;
         theBase = msi.makeTemporaryAssociateMapItem({ pdf: { url, filename, fingerprint, numPages }, n_paper: undefined, numBlankPages: undefined });
       }
-
       basePageInfo = theBase.basePageInfo;
     }
 

--- a/src/GridaBoard/GridaDoc.ts
+++ b/src/GridaBoard/GridaDoc.ts
@@ -165,8 +165,14 @@ export default class GridaDoc {
       basePageInfo = theBase.basePageInfo;
       pageInfo = theBase.printPageInfo;
     } else if (!basePageInfo) {
-      basePageInfo = pageInfo;
-      console.log(pageInfo.section);
+      const msi = MappingStorage.getInstance();
+      let theBase = msi.findAssociatedBaseNcode(pdfDoc.fingerprint);
+      if (!theBase) {
+        const { url, filename, fingerprint, numPages } = pdfDoc;
+        theBase = msi.makeTemporaryAssociateMapItem({ pdf: { url, filename, fingerprint, numPages }, n_paper: undefined, numBlankPages: undefined });
+      }
+
+      basePageInfo = theBase.basePageInfo;
     }
 
     const m0 = g_availablePagesInSection[pageInfo.section];

--- a/src/GridaBoard/Load/LoadGrida.tsx
+++ b/src/GridaBoard/Load/LoadGrida.tsx
@@ -4,8 +4,6 @@ import { InkStorage } from '../../nl-lib/common/penstorage';
 import GridaDoc from '../GridaDoc';
 
 const LoadGrida = () => {
-
-  let gridaRawData, neoStroke, gridaPageInfo, gridaInfo;
   
   async function fileOpenHandler() {
     const selectedFile = await openFileBrowser();
@@ -24,29 +22,47 @@ const LoadGrida = () => {
         const neoStroke = gridaStruct.stroke;
         const gridaPageInfo = gridaStruct.pdf.pdfInfo.pageInfo;
 
-        const pageInfo = {
-          section: gridaPageInfo.s,
-          book: gridaPageInfo.b,
-          owner: gridaPageInfo.o,
-          page: gridaPageInfo.p
-        };
+        let pageInfo = []
+        let pageId = []
 
-        const pageId = InkStorage.makeNPageIdStr(pageInfo);
-        const completed = InkStorage.getInstance().completedOnPage;
+        for (let i = 0; i < neoStroke.length; i++) {
+          pageInfo[i] = {
+            section: gridaPageInfo.s,
+            book: gridaPageInfo.b,
+            owner: gridaPageInfo.o,
+            page: gridaPageInfo.p
+          };
 
-        if (!completed.has(pageId)) {
-          completed.set(pageId, new Array(0));
+          gridaPageInfo.p++;
         }
 
-        const gridaArr = completed.get(pageId);
+        for (let i = 0; i < neoStroke.length; i++) {
+          pageId[i] = InkStorage.makeNPageIdStr(pageInfo[i]);
+        }
+        
+        const completed = InkStorage.getInstance().completedOnPage;
+
+        for (let i = 0; i < neoStroke.length; i++) {
+          if (!completed.has(pageId[i])) {
+            completed.set(pageId[i], new Array(0));
+          }
+        }
+
+        let gridaArr = [];
+
+        for (let i = 0; i < neoStroke.length; i++) {
+          gridaArr[i] = completed.get(pageId[i]);
+        }
 
         if(neoStroke !== null) {
           for (let i = 0; i < neoStroke.length; i++) {
-            gridaArr.push(neoStroke[i]);
+            for (let j = 0; j < neoStroke[i].length; j++){
+              gridaArr[i].push(neoStroke[i][j]);
+            }
           }
         }
         const doc = GridaDoc.getInstance();
-        doc.openGridaFile({ url: url, filename: file.name }, gridaRawData, neoStroke, pageInfo); 
+        doc.openGridaFile({ url: url, filename: file.name }, gridaRawData, neoStroke, pageInfo[0]); 
       }
     } else {
         alert("file open cancelled");

--- a/src/GridaBoard/Load/LoadGrida.tsx
+++ b/src/GridaBoard/Load/LoadGrida.tsx
@@ -9,11 +9,11 @@ const LoadGrida = () => {
     console.log(selectedFile.result);
 
     if (selectedFile.result === "success") {
-      const { url, file } = selectedFile;
+      let { url, file } = selectedFile;
       let jsonFile = null;
       var reader = new FileReader();
       reader.readAsText(file);
-      reader.onload = function(e) {
+      reader.onload = async function(e) {
         jsonFile = e.target.result;
 
         const gridaStruct = JSON.parse(jsonFile);
@@ -21,22 +21,29 @@ const LoadGrida = () => {
         const neoStroke = gridaStruct.stroke;
         const gridaPageInfo = gridaStruct.pdf.pdfInfo.pageInfo;
 
+        // pdf의 url을 만들어 주기 위해 rawData를 blob으로 만들어 createObjectURL을 한다
+        const rawDataBuf = new ArrayBuffer(gridaRawData.length*2);
+        const rawDataBufView = new Uint8Array(rawDataBuf);
+        for (let i = 0; i < gridaRawData.length; i++) {
+          rawDataBufView[i] = gridaRawData.charCodeAt(i);
+        }
+        const blob = new Blob([rawDataBufView], {type: 'application/pdf'});
+        url = await URL.createObjectURL(blob);
+
         const completed = InkStorage.getInstance().completedOnPage;
         completed.clear();
 
         let gridaArr = [];
-        let pageInfo = []
         let pageId = []
 
-        for (let i = 0; i < neoStroke.length; i++) {
+        const pageInfo = {
+          section: gridaPageInfo.s,
+          owner: gridaPageInfo.o,
+          book: gridaPageInfo.b,
+          page: gridaPageInfo.p
+        };
 
-          pageInfo[i] = {
-            section: gridaPageInfo.s,
-            book: gridaPageInfo.b,
-            owner: gridaPageInfo.o,
-            page: gridaPageInfo.p
-          };
-          gridaPageInfo.p++;
+        for (let i = 0; i < neoStroke.length; i++) {
 
           pageId[i] = InkStorage.makeNPageIdStr(neoStroke[i][0]);
           if (!completed.has(pageId[i])) {
@@ -50,7 +57,7 @@ const LoadGrida = () => {
         }
 
         const doc = GridaDoc.getInstance();
-        doc.openGridaFile({ url: url, filename: file.name }, gridaRawData, neoStroke, pageInfo[0]); 
+        doc.openGridaFile({ url: url, filename: file.name }, gridaRawData, neoStroke, pageInfo); 
       }
     } else {
         alert("file open cancelled");

--- a/src/GridaBoard/Load/LoadGrida.tsx
+++ b/src/GridaBoard/Load/LoadGrida.tsx
@@ -4,7 +4,6 @@ import { InkStorage } from '../../nl-lib/common/penstorage';
 import GridaDoc from '../GridaDoc';
 
 const LoadGrida = () => {
-  
   async function fileOpenHandler() {
     const selectedFile = await openFileBrowser();
     console.log(selectedFile.result);
@@ -22,45 +21,34 @@ const LoadGrida = () => {
         const neoStroke = gridaStruct.stroke;
         const gridaPageInfo = gridaStruct.pdf.pdfInfo.pageInfo;
 
+        const completed = InkStorage.getInstance().completedOnPage;
+        completed.clear();
+
+        let gridaArr = [];
         let pageInfo = []
         let pageId = []
 
         for (let i = 0; i < neoStroke.length; i++) {
+
           pageInfo[i] = {
             section: gridaPageInfo.s,
             book: gridaPageInfo.b,
             owner: gridaPageInfo.o,
             page: gridaPageInfo.p
           };
-
           gridaPageInfo.p++;
-        }
 
-        for (let i = 0; i < neoStroke.length; i++) {
-          pageId[i] = InkStorage.makeNPageIdStr(pageInfo[i]);
-        }
-        
-        const completed = InkStorage.getInstance().completedOnPage;
-
-        for (let i = 0; i < neoStroke.length; i++) {
+          pageId[i] = InkStorage.makeNPageIdStr(neoStroke[i][0]);
           if (!completed.has(pageId[i])) {
             completed.set(pageId[i], new Array(0));
           }
-        }
 
-        let gridaArr = [];
-
-        for (let i = 0; i < neoStroke.length; i++) {
           gridaArr[i] = completed.get(pageId[i]);
+          for (let j = 0; j < neoStroke[i].length; j++){
+            gridaArr[i].push(neoStroke[i][j]);
+          } 
         }
 
-        if(neoStroke !== null) {
-          for (let i = 0; i < neoStroke.length; i++) {
-            for (let j = 0; j < neoStroke[i].length; j++){
-              gridaArr[i].push(neoStroke[i][j]);
-            }
-          }
-        }
         const doc = GridaDoc.getInstance();
         doc.openGridaFile({ url: url, filename: file.name }, gridaRawData, neoStroke, pageInfo[0]); 
       }

--- a/src/GridaBoard/Save/SaveGrida.tsx
+++ b/src/GridaBoard/Save/SaveGrida.tsx
@@ -50,7 +50,7 @@ export async function saveGrida(gridaName: string) {
       if (pdfUrl !== page.pdf.url) {
         pdfUrl = page.pdf.url;
         const existingPdfBytes = await fetch(page.pdf.url).then(res => res.arrayBuffer());
-        let pdfDocSrc = await PDFDocument.load(existingPdfBytes); // 다시 저장하면 여기서 오류
+        let pdfDocSrc = await PDFDocument.load(existingPdfBytes);
   
         if (pdfDoc !== undefined) {
           //ncode 페이지가 미리 생성돼서 그 뒤에다 붙여야하는 경우
@@ -188,7 +188,7 @@ export async function saveGrida(gridaName: string) {
 
   const mappingInfoStr = JSON.stringify(gridaJson);
 
-  const blob = new Blob([mappingInfoStr], { type: 'eapplication/json' });
+  const blob = new Blob([mappingInfoStr], { type: 'application/json' });
   saveAs(blob, gridaName);
   
 }

--- a/src/GridaBoard/Save/SaveGrida.tsx
+++ b/src/GridaBoard/Save/SaveGrida.tsx
@@ -6,6 +6,8 @@ import { fabric } from "fabric";
 import { drawPath } from "../../nl-lib/common/util";
 import GridaPage from "../GridaPage";
 
+import fs from 'fs';
+
 const PDF_TO_SCREEN_SCALE = 6.72; // (56/600)*72
 
 const inkSt = InkStorage.getInstance();
@@ -53,8 +55,34 @@ export async function saveGrida(gridaName: string) {
       //pdf인 경우
       if (pdfUrl !== page.pdf.url) {
         pdfUrl = page.pdf.url;
-        existingPdfBytes = await fetch(page.pdf.url).then(res => res.arrayBuffer());
-        let pdfDocSrc = await PDFDocument.load(existingPdfBytes); // 다시 저장하면 여기서 오류
+        // existingPdfBytes = await fetch(page.pdf.url).then(res => res.arrayBuffer());
+
+        var _fileLen = page.pdf.filename.length;
+
+        var _lastDot = page.pdf.filename.lastIndexOf('.');
+    
+        var _fileExt = page.pdf.filename.substring(_lastDot, _fileLen).toLowerCase();
+
+        var _fileName = page.pdf.filename;
+
+        let pdfDocSrc;
+        if (_fileExt === '.pdf') {
+          existingPdfBytes = await fetch(page.pdf.url).then(res => res.arrayBuffer());
+          pdfDocSrc = await PDFDocument.load(existingPdfBytes); // 다시 저장하면 여기서 오류
+        } else if (_fileExt === '.grida') {
+          // existingPdfBytes = await fetch(_fileName).then(res => res.arrayBuffer());
+          // const bufViewUint8 = new Uint8Array(existingPdfBytes);
+          // existingPdfBytes = fs.readFile(_fileName, 'utf-8', function (err, data) {
+          //   console.log(existingPdfBytes);
+          // });
+          // let buffer = existingPdfBytes.decode(page.pdf.url);
+          // var uint8View = new Uint8Array(buffer);
+          // var request = new XMLHttpRequest();
+          // request.open('GET', pdfUrl);
+          existingPdfBytes = await fetch(page.pdf.url).then(res => res.arrayBuffer());
+          pdfDocSrc = await PDFDocument.load(existingPdfBytes);
+        }
+        // let pdfDocSrc = await PDFDocument.load(existingPdfBytes);
   
         if (pdfDoc !== undefined) {
           //ncode 페이지가 미리 생성돼서 그 뒤에다 붙여야하는 경우
@@ -164,19 +192,6 @@ export async function saveGrida(gridaName: string) {
           pointArray.push({ x: pdf_xy.x, y: pdf_xy.y, f: dot.f });
         }
       }
-      const strokeThickness = thickness / 64;
-      const pathData = drawPath(pointArray, strokeThickness);
-      
-      page.moveTo(0, pageHeight);
-      page.drawSvgPath(pathData, {
-        color: rgb(
-          Number(rgbStrArr[0]) / 255,
-          Number(rgbStrArr[1]) / 255,
-          Number(rgbStrArr[2]) / 255
-        ),
-        opacity: opacity,
-        scale: 1,
-      });
     }
   }
 
@@ -197,7 +212,7 @@ export async function saveGrida(gridaName: string) {
     } 
   };
 
-  let stroke = strokeInfos[0];
+  let stroke = strokeInfos;
 
   let gridaInfo = {
     gridaDate : gridaDate,

--- a/src/nl-lib/common/neopdf/NeoPdfDocument.ts
+++ b/src/nl-lib/common/neopdf/NeoPdfDocument.ts
@@ -109,7 +109,6 @@ export class NeoPdfDocument {
     const pdfDoc = await gridaJsOpenDocument(options, gridaStruct, neoStroke);
     console.log("~GRIDA DOC~,   load, step 2")
 
-
     const { url, filename, purpose } = options;
 
     this._url = url;
@@ -120,7 +119,6 @@ export class NeoPdfDocument {
     this._pdfDoc = pdfDoc;
     _doc_fingerprint = pdfDoc.fingerprint;
 
-
     // page를 로드한다
     if (pdfDoc) {
       this._pages = [];
@@ -128,11 +126,9 @@ export class NeoPdfDocument {
         const neoPage = new NeoPdfPage(this, i + 1);
         this._pages.push(neoPage);
       }
-
       await this.setPageOverview();
       return this;
     }
-
     return undefined;
   }
 


### PR DESCRIPTION
pdf와 stroke를 분리시켜 load시 stroke 배열화로 page마다 올바르게 stroke가 찍힐 수 있게 바꾸고
load시에 stroke를 지워질 수 있게 수정했습니다.
addPage시 page가 0으로 찍히는 것을 방지하기 위해 GridaDoc에 appendPdfDocument에 basePageInfo값을 theBase로 지정했습니다.