### PR TITLE
[Feat] DnD 등 새 파일 불러올 시 DocName이 리로드되지 않도록 개선

### DIFF
--- a/src/GridaBoard/Load/ConvertFileLoad.tsx
+++ b/src/GridaBoard/Load/ConvertFileLoad.tsx
@@ -31,6 +31,7 @@ interface cloudImportResponse {
 
 interface Props extends ButtonProps {
   handlePdfOpen: (event: IFileBrowserReturn) => void,
+  isNewLoad?: Boolean
 }
 // 그리다 파일을 불러왔을때 이용
 function fileConvert(selectedFile){
@@ -118,7 +119,7 @@ const checkPdfIsEncryptted = (selectedFile) => {
 
 const ConvertFileLoad = (props: Props) => {
   const [canConvert, setCanConvert] = useState(true);
-  const { handlePdfOpen } = props;
+  const { handlePdfOpen, isNewLoad } = props;
   const history = useHistory();
 
   async function inputChange()
@@ -142,8 +143,8 @@ const ConvertFileLoad = (props: Props) => {
     
     const fileType = fullFileName.substring(foundPosArr[foundPosArr.length - 1] + 1, fullFileName.length);
     fullFileName = fullFileName.substring(0, foundPosArr[foundPosArr.length - 1]);
-    setDocName(fullFileName);
-
+    (isNewLoad) ? setDocName(fullFileName) : null;
+    
     const result = {
       result : "success",
       file : null,

--- a/src/GridaBoard/View/Drawer/ThumbnailItem.tsx
+++ b/src/GridaBoard/View/Drawer/ThumbnailItem.tsx
@@ -125,8 +125,14 @@ const ThumbnailItem = (props: Props) => {
   const sizePu = pageOverview.sizePu;
   const pageInfo = page.pageInfos[0];
 
+  const moveToThumbnailScroll = (pageNo:number) => {
+    const thumbnail= document.getElementById("thumbnail - " + pageNo + " -mixed_view");
+    thumbnail.scrollIntoView({block: "center", behavior: "smooth"});
+  }
+  
   const handleMouseDown = (pageNo:number) => {
     setActivePageNo(pageNo);
+    moveToThumbnailScroll(pageNo);
   };
 
   const wh_ratio = sizePu.width / sizePu.height;

--- a/src/GridaBoard/components/buttons/ConnectButton.tsx
+++ b/src/GridaBoard/components/buttons/ConnectButton.tsx
@@ -67,7 +67,7 @@ const ConnectButton = (props: Props) => {
           + {getText("pen_connect")}
         </Button>
       ) : (
-        <Button className={classes.connectBtn} variant="contained" color="primary" onClick={() => handleConnectPen()}>
+        <Button className={classes.connectBtn} variant="contained" color="inherit" onClick={() => handleConnectPen()}>
         {getText("pen_connect_count")} ({numPens})
         </Button>
       )}

--- a/src/GridaBoard/components/buttons/RotateButton.tsx
+++ b/src/GridaBoard/components/buttons/RotateButton.tsx
@@ -5,7 +5,7 @@ import { setRotationTrigger } from '../../store/reducers/rotate';
 import { useSelector } from 'react-redux';
 import GridaDoc from "../../GridaDoc";
 import { IconButton, IconButtonProps, makeStyles, SvgIcon } from "@material-ui/core";
-import { RotateRight } from "@material-ui/icons";
+import { RotateRight, RotateLeft } from "@material-ui/icons";
 import SimpleTooltip2 from "../SimpleTooltip2";
 import getText from 'GridaBoard/language/language';
 import { store } from "GridaBoard/client/pages/GridaBoard";
@@ -22,17 +22,17 @@ export const onToggleRotate = () => {
   const page = doc.getPageAt(activePageNo);
 
   if (page._pdfPage !== undefined) {
-    if (page._pdfPage.viewport.rotation >= 270) {
+    if (page._pdfPage.viewport.rotation <= -270) {
       page._pdfPage.viewport.rotation = 0;
     } else {
-      page._pdfPage.viewport.rotation += 90;
+      page._pdfPage.viewport.rotation -= 90;
     }
   }
 
-  if (page.pageOverview.rotation >= 270) {
+  if (page.pageOverview.rotation <= -270) {
     page._rotation = 0;
   } else {
-    page._rotation += 90;
+    page._rotation -= 90;
   }
 
   // setIsVertical((prev)=>!prev);
@@ -62,7 +62,7 @@ const RotateButton = (props: IconButtonProps) => {
   return (
     <IconButton onClick={onToggleRotate} {...props}>
       <SimpleTooltip2 title={getText('sideMenu_rotate')}>
-        <RotateRight/>
+        <RotateLeft/>
       </SimpleTooltip2>
     </IconButton>
   );

--- a/src/boardList/layout/component/mainContent/MainNewButton.tsx
+++ b/src/boardList/layout/component/mainContent/MainNewButton.tsx
@@ -184,7 +184,7 @@ const MainNewButton = () => {
                       />
                     </SvgIcon>
                     <span style={{ marginLeft: '9px' }}>{options[1]}</span>
-                    <ConvertFileLoad handlePdfOpen={handlePdfOpen} />
+                    <ConvertFileLoad handlePdfOpen={handlePdfOpen} isNewLoad={true}/>
                   </MenuItem>
                 </MenuList>
               </ClickAwayListener>

--- a/src/nl-lib/renderer/penview/RenderWorkerBase.tsx
+++ b/src/nl-lib/renderer/penview/RenderWorkerBase.tsx
@@ -998,15 +998,15 @@ export default abstract class RenderWorkerBase {
     this._opt.rotation = rotation;
 
     switch (rotation) {
-      case 90: {
+      case -270: {
         this._opt.h = calcRotatedH90(this.h, { width: pdfSize.width, height: pdfSize.height });
         break;
       }
-      case 180: {
+      case -180: {
         this._opt.h = calcRotatedH180(this.h, { width: pdfSize.height, height: pdfSize.width });
         break;
       }
-      case 270: {
+      case -90: {
         this._opt.h = calcRotatedH270(this.h, { width: pdfSize.width, height: pdfSize.height });
         break;
       }
@@ -1023,15 +1023,15 @@ export default abstract class RenderWorkerBase {
     // this.h_rev = calcRevH(h);
 
     switch (this._opt.rotation) {
-      case 90: {
+      case -270: {
         this._opt.h = calcRotatedH90(this.h, { width: pdfSize_pu.width, height: pdfSize_pu.height });
         break;
       }
-      case 180: {
+      case -180: {
         this._opt.h = calcRotatedH180(this.h, { width: pdfSize_pu.height, height: pdfSize_pu.width });
         break;
       }
-      case 270: {
+      case -90: {
         this._opt.h = calcRotatedH270(this.h, { width: pdfSize_pu.width, height: pdfSize_pu.height });
         break;
       }


### PR DESCRIPTION
1. [Feat] 기존 파일 열려진 상태에서 새 파일 불러오거나 DnD할 경우 DocName(타이틀)이 변경되지 않도록 변경
         -> 새 파일 불러올 때만 이름 변경
2. [Feat] LeftSideLayer의 썸네일 클릭 시 해당 영역 스크롤도 중앙으로 이동
3. [Chore] 연결된 펜 박스 색상 변경
4. [Chore] 회전 기능 수행 시 기존 시계 방향 회전에서 반시계 방향 회전으로 변경