### PR TITLE
[Feat] 불러오기 시 타이틀 미변경 및 스크롤 이동의 건

### DIFF
--- a/src/GridaBoard/GridaDoc.ts
+++ b/src/GridaBoard/GridaDoc.ts
@@ -6,12 +6,11 @@ import { RootState } from "./store/rootReducer";
 import { g_availablePagesInSection, nullNcode } from "nl-lib/common/constants";
 import { NeoPdfDocument, IPdfOpenOption, NeoPdfManager, PdfManagerEventName, IPdfManagerEvent } from "nl-lib/common/neopdf";
 import { IPdfToNcodeMapItem, IPageSOBP, IGetNPageTransformType } from "nl-lib/common/structures";
-import { isSamePage, makeNPageIdStr } from "nl-lib/common/util";
+import { isSamePage, makeNPageIdStr, scrollToThumbnail } from "nl-lib/common/util";
 
 
 import { InkStorage } from "nl-lib/common/penstorage";
 import { MappingStorageEventName, IMappingStorageEvent, MappingStorage } from "nl-lib/common/mapper";
-import { scrollToBottom } from "nl-lib/common/util";
 import getText from "./language/language";
 
 
@@ -121,13 +120,13 @@ export default class GridaDoc {
 
     if (pdfDoc) {
       let activePageNo = await this.appendPdfDocument(pdfDoc, pageInfo, basePageInfo);
-      scrollToBottom("drawer_content");
 
       if (activePageNo === -1) {
         const state = store.getState() as RootState;
         activePageNo = state.activePage.activePageNo;
       }
       this.setActivePageNo(activePageNo);
+      scrollToThumbnail(activePageNo)
     }
   }
 
@@ -150,8 +149,8 @@ export default class GridaDoc {
       }
 
       
-      scrollToBottom("drawer_content");
       this.setActivePageNo(activePageNo);
+      scrollToThumbnail(activePageNo)
 
       const msi = MappingStorage.getInstance();
       msi.dispatcher.dispatch(MappingStorageEventName.ON_MAPINFO_REFRESHED, null);
@@ -384,6 +383,7 @@ export default class GridaDoc {
           const activePageNo = this.addNcodePage(pageInfo);
           setDocNumPages(this._pages.length);
           setActivePageNo(activePageNo);
+          scrollToThumbnail(activePageNo)
           break;
         }
       }

--- a/src/GridaBoard/Load/ConvertFileLoad.tsx
+++ b/src/GridaBoard/Load/ConvertFileLoad.tsx
@@ -31,6 +31,7 @@ interface cloudImportResponse {
 
 interface Props extends ButtonProps {
   handlePdfOpen: (event: IFileBrowserReturn) => void,
+  isNewLoad?: Boolean
 }
 // 그리다 파일을 불러왔을때 이용
 function fileConvert(selectedFile){
@@ -118,7 +119,7 @@ const checkPdfIsEncryptted = (selectedFile) => {
 
 const ConvertFileLoad = (props: Props) => {
   const [canConvert, setCanConvert] = useState(true);
-  const { handlePdfOpen } = props;
+  const { handlePdfOpen, isNewLoad } = props;
   const history = useHistory();
 
   async function inputChange()
@@ -142,8 +143,8 @@ const ConvertFileLoad = (props: Props) => {
     
     const fileType = fullFileName.substring(foundPosArr[foundPosArr.length - 1] + 1, fullFileName.length);
     fullFileName = fullFileName.substring(0, foundPosArr[foundPosArr.length - 1]);
-    setDocName(fullFileName);
-
+    (isNewLoad) ? setDocName(fullFileName) : null;
+    
     const result = {
       result : "success",
       file : null,

--- a/src/GridaBoard/View/Drawer/ThumbnailItem.tsx
+++ b/src/GridaBoard/View/Drawer/ThumbnailItem.tsx
@@ -125,8 +125,14 @@ const ThumbnailItem = (props: Props) => {
   const sizePu = pageOverview.sizePu;
   const pageInfo = page.pageInfos[0];
 
+  const moveToThumbnailScroll = (pageNo:number) => {
+    const thumbnail= document.getElementById("thumbnail - " + pageNo + " -mixed_view");
+    thumbnail.scrollIntoView({block: "center", behavior: "smooth"});
+  }
+  
   const handleMouseDown = (pageNo:number) => {
     setActivePageNo(pageNo);
+    moveToThumbnailScroll(pageNo);
   };
 
   const wh_ratio = sizePu.width / sizePu.height;

--- a/src/GridaBoard/components/buttons/BoardNewButton.tsx
+++ b/src/GridaBoard/components/buttons/BoardNewButton.tsx
@@ -5,7 +5,7 @@ import getText from 'GridaBoard/language/language';
 import GridaDoc from 'GridaBoard/GridaDoc';
 import { IFileBrowserReturn, IPageSOBP } from 'nl-lib/common/structures';
 import ConvertFileLoad from 'GridaBoard/Load/ConvertFileLoad';
-import { scrollToBottom } from '../../../nl-lib/common/util';
+import { scrollToThumbnail } from '../../../nl-lib/common/util';
 import { setActivePageNo } from '../../store/reducers/activePageReducer';
 import { firebaseAnalytics } from '../../util/firebase_config';
 
@@ -88,7 +88,7 @@ const BoardNewButton = () => {
     const doc = GridaDoc.getInstance();
     const pageNo = await doc.addBlankPage();
     setActivePageNo(pageNo);
-    scrollToBottom("drawer_content");
+    scrollToThumbnail(pageNo);
     setOpen(false);
 
     firebaseAnalytics.logEvent('new_page', {

--- a/src/boardList/layout/component/mainContent/MainNewButton.tsx
+++ b/src/boardList/layout/component/mainContent/MainNewButton.tsx
@@ -184,7 +184,7 @@ const MainNewButton = () => {
                       />
                     </SvgIcon>
                     <span style={{ marginLeft: '9px' }}>{options[1]}</span>
-                    <ConvertFileLoad handlePdfOpen={handlePdfOpen} />
+                    <ConvertFileLoad handlePdfOpen={handlePdfOpen} isNewLoad={true}/>
                   </MenuItem>
                 </MenuList>
               </ClickAwayListener>

--- a/src/nl-lib/common/util/functions.ts
+++ b/src/nl-lib/common/util/functions.ts
@@ -450,7 +450,13 @@ export function callstackDepth() {
 
 export function scrollToBottom(id: string) {
   const ele = document.querySelector("#" + id);
-  ele.scrollIntoView({ behavior: "smooth", block: "end" });
+  (ele) ? ele.scrollIntoView({ behavior: "smooth", block: "end" }) : null;
+  // (ele) ? ele.scrollTo(0, ele.scrollHeight) : null;
+}
+
+export function scrollToThumbnail(pageNo : Number){
+  const ele = document.getElementById("thumbnail - " + pageNo + " -mixed_view");
+  (ele) ? ele.scrollIntoView({behavior: "smooth"}) : null;
 }
 
 


### PR DESCRIPTION
1. [Feat] 기존 파일 열려진 상태에서 새 파일 불러오거나 DnD할 경우 DocName(타이틀)이 변경되지 않도록 변경
-> 새 파일 불러올 때만 이름 변경
2. [Feat] LeftSideLayer의 썸네일 클릭 시 해당 영역 스크롤도 중앙으로 이동
3. [Feat] 파일 로드 시 활성화된 썸네일로 스크롤 이동