### PR TITLE
[제스처] 부기보드의 요구사항 변경에 따른 제스쳐 관련 코드 업데이트

### DIFF
--- a/src/GridaBoard/GridaPage.tsx
+++ b/src/GridaBoard/GridaPage.tsx
@@ -98,6 +98,7 @@ export default class GridaPage {
     const pageInfo = this.getPageInfoAt(0);
     // undefined인 경우도 있을 것 같긴하다. 아래의 getNPaperSize_pu에서 예외처리 하고 있다.
     const pageSize = getNPaperSize_pu(pageInfo);
+    const landscape = pageSize.width > pageSize.height;
 
     //ncode 페이지는 NPaperSize_pu 안에서 회전 처리를 안하기 때문에 여기서 따로 바꿔준다
     if (this._rotation === 90 || this._rotation === 270) {
@@ -106,7 +107,6 @@ export default class GridaPage {
       pageSize.height = tmp;
     }
     
-    const landscape = pageSize.width > pageSize.height;
     const retVal: IPageOverview = {
       sizePu: pageSize,
       rotation: this._rotation,

--- a/src/GridaBoard/store/reducers/gestureReducer.ts
+++ b/src/GridaBoard/store/reducers/gestureReducer.ts
@@ -1,9 +1,11 @@
 import { NeoDot } from "../../../nl-lib/common/structures";
 import { store } from "../../client/pages/GridaBoard";
 
+
 const DoubleTapActionGroup = "DOUBLE_TAP";
 const CrossLineActionGroup = "CROSS_LINE";
 const SymbolActionGroup = "SYMBOL";
+
 
 const DoubleTapActionType = Object.freeze({
   INITIALIZE_TAP: `${DoubleTapActionGroup}.INITIALIZE_TAP`,
@@ -24,6 +26,7 @@ const SymbolActionType = Object.freeze({
 });
 
 const SET_HIDE_CANVAS = 'SET_HIDE_CANVAS';
+
 
 // Double Tap Action Function
 export const initializeTap = () => {
@@ -156,7 +159,7 @@ export default function gestureReducer(state = initialState, action) {
         ...state,
         symbol: {
           ...state.symbol,
-          notFirstSymbol: true
+          notFirstPenDown: true
         }
       }
     case SymbolActionType.SHOW:

--- a/src/GridaBoard/store/reducers/gestureReducer.ts
+++ b/src/GridaBoard/store/reducers/gestureReducer.ts
@@ -1,53 +1,82 @@
 import { NeoDot } from "../../../nl-lib/common/structures";
 import { store } from "../../client/pages/GridaBoard";
 
-const INCREMENT_TAP_COUNT = 'INCREMENT_TAP_COUNT';
-const INITIALIZE_TAP_COUNT = 'INITIALIZE_TAP_COUNT';
-const SET_FIRST_TAP = 'SET_FIRST_TAP';
+const DoubleTapActionGroup = "DOUBLE_TAP";
+const CrossLineActionGroup = "CROSS_LINE";
+const SymbolActionGroup = "SYMBOL";
 
-const INITIALIZE_DIAGONAL = 'INITIALIZE_DIAGONAL';
-const SET_LEFT_TO_RIGHT_DIAGONAL = 'SET_LEFT_TO_RIGHT_DIAGONAL';
-const SET_RIGHT_TO_LEFT_DIAGONAL = 'SET_RIGHT_TO_LEFT_DIAGONAL';
+const DoubleTapActionType = Object.freeze({
+  INITIALIZE_TAP: `${DoubleTapActionGroup}.INITIALIZE_TAP`,
+  INCREMENT_TAP_COUNT: `${DoubleTapActionGroup}.INCREMENT_TAP_COUNT`,
+  SET_FIRST_DOT: `${DoubleTapActionGroup}.SET_FIRST_DOT`,
+});
+
+const CrossLineActionType = Object.freeze({
+  INITIALIZE_CROSS_LINE: `${CrossLineActionGroup}.INITIALIZE_CROSS_LINE`,
+  SET_LEFT_TO_RIGHT_DIAGONAL: `${CrossLineActionGroup}.SET_LEFT_TO_RIGHT_DIAGONAL`,
+  SET_RIGHT_TO_LEFT_DIAGONAL: `${CrossLineActionGroup}.SET_RIGHT_TO_LEFT_DIAGONAL`,
+});
+
+const SymbolActionType = Object.freeze({
+  SET_NOT_FIRST_PEN_DOWN: `${SymbolActionGroup}.SET_NOT_FIRST_PEN_DOWN`,
+  SHOW: `${SymbolActionGroup}.SHOW`,
+  HIDE: `${SymbolActionGroup}.HIDE`
+});
 
 const SET_HIDE_CANVAS = 'SET_HIDE_CANVAS';
 
-// 액션 생성 함수
+// Double Tap Action Function
+export const initializeTap = () => {
+  store.dispatch({
+    type: DoubleTapActionType.INITIALIZE_TAP
+  });
+};
 export const incrementTapCount = () => {
   store.dispatch({
-    type: INCREMENT_TAP_COUNT
+    type: DoubleTapActionType.INCREMENT_TAP_COUNT
   });
 };
-
-export const initializeTapCount = () => {
+export const setFirstDot = (firstDot: NeoDot) => {
   store.dispatch({
-    type: INITIALIZE_TAP_COUNT
+    type: DoubleTapActionType.SET_FIRST_DOT, firstDot
   });
 };
 
-export const setFirstTap = (firstDot: NeoDot) => {
+// Cross Line Action Function
+export const initializeCrossLine = () => {
   store.dispatch({
-    type: SET_FIRST_TAP, firstDot
+    type: CrossLineActionType.INITIALIZE_CROSS_LINE
   });
 };
-
 export const setLeftToRightDiagonal = () => {
   store.dispatch({
-    type: SET_LEFT_TO_RIGHT_DIAGONAL
+    type: CrossLineActionType.SET_LEFT_TO_RIGHT_DIAGONAL
   });
 };
-
 export const setRightToLeftDiagonal = () => {
   store.dispatch({
-    type: SET_RIGHT_TO_LEFT_DIAGONAL
+    type: CrossLineActionType.SET_RIGHT_TO_LEFT_DIAGONAL
   });
 };
 
-export const initializeDiagonal = () => {
+// Symbol Action Function
+export const setNotFirstPenDown = () => {
   store.dispatch({
-    type: INITIALIZE_DIAGONAL
+    type: SymbolActionType.SET_NOT_FIRST_PEN_DOWN
   });
 };
+export const showSymbol = () => {
+  store.dispatch({
+    type: SymbolActionType.SHOW
+  });
+}
+export const hideSymbol = () => {
+  store.dispatch({
+    type: SymbolActionType.HIDE
+  });
+}
 
+// Hide Canvas Action Function
 export const setHideCanvas = (hideCanvas: boolean) => {
   store.dispatch({
     type: SET_HIDE_CANVAS, hideCanvas
@@ -64,13 +93,17 @@ const initialState = {
     leftToRightDiagonal: false,
     rightToLeftDiagonal: false
   },
-  hideCanvas: false
+  symbol: {
+    notFirstPenDown: false,
+    show: false,
+  },
+  hideCanvas: false,
 };
 
 // 리듀서
 export default function gestureReducer(state = initialState, action) {
   switch (action.type) {
-    case INITIALIZE_TAP_COUNT:
+    case DoubleTapActionType.INITIALIZE_TAP:
       return {
         ...state,
         doubleTap: {
@@ -78,7 +111,7 @@ export default function gestureReducer(state = initialState, action) {
           firstDot: null
         }
       }
-    case INCREMENT_TAP_COUNT:
+    case DoubleTapActionType.INCREMENT_TAP_COUNT:
       return {
         ...state,
         doubleTap: {
@@ -86,7 +119,7 @@ export default function gestureReducer(state = initialState, action) {
           tapCount: state.doubleTap.tapCount+1
         }
       };
-    case SET_FIRST_TAP:
+    case DoubleTapActionType.SET_FIRST_DOT:
       return {
         ...state,
         doubleTap: {
@@ -94,7 +127,7 @@ export default function gestureReducer(state = initialState, action) {
           firstDot: action.firstDot
         }
       }
-    case INITIALIZE_DIAGONAL:
+    case CrossLineActionType.INITIALIZE_CROSS_LINE:
       return {
         ...state,
         crossLine: {
@@ -102,7 +135,7 @@ export default function gestureReducer(state = initialState, action) {
           rightToLeftDiagonal: false  
         }
       }
-    case SET_LEFT_TO_RIGHT_DIAGONAL:
+    case CrossLineActionType.SET_LEFT_TO_RIGHT_DIAGONAL:
       return {
         ...state,
         crossLine: {
@@ -110,7 +143,7 @@ export default function gestureReducer(state = initialState, action) {
           leftToRightDiagonal: true
         }
       }
-    case SET_RIGHT_TO_LEFT_DIAGONAL:
+    case CrossLineActionType.SET_RIGHT_TO_LEFT_DIAGONAL:
       return {
         ...state,
         crossLine: {
@@ -118,6 +151,30 @@ export default function gestureReducer(state = initialState, action) {
           rightToLeftDiagonal: true
         }
       }
+    case SymbolActionType.SET_NOT_FIRST_PEN_DOWN:
+      return {
+        ...state,
+        symbol: {
+          ...state.symbol,
+          notFirstSymbol: true
+        }
+      }
+    case SymbolActionType.SHOW:
+      return {
+        ...state,
+        symbol: {
+          ...state.symbol,
+          show: true
+        }
+      }
+    case SymbolActionType.HIDE:
+      return {
+        ...state,
+        symbol: {
+          ...state.symbol,
+          show: false
+        }
+      }  
     case SET_HIDE_CANVAS:
       return {
         ...state,

--- a/src/GridaBoard/store/reducers/gestureReducer.ts
+++ b/src/GridaBoard/store/reducers/gestureReducer.ts
@@ -63,9 +63,9 @@ export const setRightToLeftDiagonal = () => {
 };
 
 // Symbol Action Function
-export const setNotFirstPenDown = () => {
+export const setNotFirstPenDown = (notFirstPenDown: boolean) => {
   store.dispatch({
-    type: SymbolActionType.SET_NOT_FIRST_PEN_DOWN
+    type: SymbolActionType.SET_NOT_FIRST_PEN_DOWN, notFirstPenDown
   });
 };
 export const showSymbol = () => {
@@ -159,7 +159,7 @@ export default function gestureReducer(state = initialState, action) {
         ...state,
         symbol: {
           ...state.symbol,
-          notFirstPenDown: true
+          notFirstPenDown: action.notFirstPenDown
         }
       }
     case SymbolActionType.SHOW:

--- a/src/nl-lib/common/constants/MapperConstants.ts
+++ b/src/nl-lib/common/constants/MapperConstants.ts
@@ -39,7 +39,7 @@ export const PlateNcode_3: IPageSOBP = { // 부기보드
   section: 3,
   owner: 1013,
   book: 2,
-  page: 14,
+  page: 16,
 }
 
 export const FilmNcode_Landscape: IPageSOBP = {

--- a/src/nl-lib/common/noteserver/SurfaceInfo.ts
+++ b/src/nl-lib/common/noteserver/SurfaceInfo.ts
@@ -1,6 +1,6 @@
 import { g_paperType } from "./NcodeSurfaceDataJson";
 import { INcodeSOBPxy, INoteServerItem_forPOD, IPageSOBP, IPaperSize, ISize } from "../structures";
-import { FilmNcode_Landscape, FilmNcode_Portrait, INCH_TO_MM_SCALE, NCODE_TO_INCH_SCALE, PDF_DEFAULT_DPI, PlateNcode_3, UNIT_TO_DPI } from "../constants";
+import { FilmNcode_Landscape, FilmNcode_Portrait, INCH_TO_MM_SCALE, NCODE_TO_INCH_SCALE, PDF_DEFAULT_DPI, PlateNcode_2, PlateNcode_3, UNIT_TO_DPI } from "../constants";
 import { isSamePage } from "../util";
 
 
@@ -144,12 +144,19 @@ export function adjustNoteItemMarginForFilm(noteItem: INoteServerItem_forPOD, pa
     noteItem.margin.Xmax = 128;
     noteItem.margin.Ymax = 91;
   }
+  else if(isSamePage(pageInfo, PlateNcode_2)){
+    // 일단 임시로 이 위치
+    noteItem.margin.Xmin = 0; 
+    noteItem.margin.Ymin = 0;
+    noteItem.margin.Xmax = 108;
+    noteItem.margin.Ymax = 60;
+  }
   else if(isSamePage(pageInfo, PlateNcode_3)){
     // 일단 임시로 이 위치
     noteItem.margin.Xmin = 0; 
     noteItem.margin.Ymin = 0;
     noteItem.margin.Xmax = 77;
-    noteItem.margin.Ymax = 55;
+    noteItem.margin.Ymax = 57;
   }
 }
 

--- a/src/nl-lib/common/noteserver/SurfaceInfo.ts
+++ b/src/nl-lib/common/noteserver/SurfaceInfo.ts
@@ -148,8 +148,8 @@ export function adjustNoteItemMarginForFilm(noteItem: INoteServerItem_forPOD, pa
     // 일단 임시로 이 위치
     noteItem.margin.Xmin = 0; 
     noteItem.margin.Ymin = 0;
-    noteItem.margin.Xmax = 55;
-    noteItem.margin.Ymax = 77;
+    noteItem.margin.Xmax = 77;
+    noteItem.margin.Ymax = 55;
   }
 }
 

--- a/src/nl-lib/renderer/penview/PenBasedRenderWorker.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderWorker.tsx
@@ -220,7 +220,6 @@ export default class PenBasedRenderWorker extends RenderWorkerBase {
     }
 
     let isPlate = false;
-    console.log(pageInfo);
     if (isPlatePage(pageInfo)) {
       isPlate = true;
     }

--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -19,7 +19,7 @@ import {isPlatePaper, isPUI, getNPaperInfo, adjustNoteItemMarginForFilm} from "n
 import {setCalibrationData} from 'GridaBoard/store/reducers/calibrationDataReducer';
 import {store} from "GridaBoard/client/pages/GridaBoard";
 import GridaDoc from "GridaBoard/GridaDoc";
-import { initializeCrossLine, setLeftToRightDiagonal, setRightToLeftDiagonal, setHideCanvas, incrementTapCount, initializeTap, setFirstDot } from "GridaBoard/store/reducers/gestureReducer";
+import { initializeCrossLine, setLeftToRightDiagonal, setRightToLeftDiagonal, setHideCanvas, incrementTapCount, initializeTap, setFirstDot, setNotFirstPenDown, showSymbol, hideSymbol } from "GridaBoard/store/reducers/gestureReducer";
 import { setActivePageNo } from "GridaBoard/store/reducers/activePageReducer";
 import { onToggleRotate } from "GridaBoard/components/buttons/RotateButton";
 import { showMessageToast } from "GridaBoard/store/reducers/ui";
@@ -96,6 +96,12 @@ interface Props { // extends MixedViewProps {
 
   hideCanvas: boolean;
   setHideCanvas: any;
+
+  notFirstPenDown: boolean;
+  show: boolean;
+  setNotFirstPenDown: any;
+  showSymbol: any;
+  hideSymbol: any;
 }
 
 /**
@@ -531,6 +537,10 @@ class PenBasedRenderer extends React.Component<Props, State> {
     if (this.props.hideCanvas) {
       showMessageToast(getText('hide_canvas'));
     }
+    if (!this.props.notFirstPenDown) {
+      this.onSymbolUp();
+      this.props.setNotFirstPenDown();
+    }
     if (this.renderer) {
       // const { section, owner, book, page } = event;
       // if (isSamePage(this.props.pageInfo, { section, owner, book, page }))
@@ -682,7 +692,7 @@ class PenBasedRenderer extends React.Component<Props, State> {
 
   /** Left Control Zone - Rotate */
   leftControlZone = () => {
-    showMessageToast(getText('check_symbol_position'));
+    this.onSymbolUp();
     onToggleRotate();
   }
 
@@ -1077,6 +1087,14 @@ class PenBasedRenderer extends React.Component<Props, State> {
     return pageMode === "portrait" ? (this.props.rotation+90)%360 : this.props.rotation 
   }
 
+  onSymbolUp = () => {
+    showMessageToast(getText('check_symbol_position'));
+    this.props.showSymbol();
+    setTimeout(function() {
+      hideSymbol();
+    }, 3000);
+  }
+
   render() {
     let { zoom } = this.props.position;
 
@@ -1112,7 +1130,7 @@ class PenBasedRenderer extends React.Component<Props, State> {
     const symbolSize: CSSProperties = {
       fontSize: 50,
       color: '#ff2222',
-      visibility: this.state.numDocPages > 0 && this.props.isMainView ? 'visible' : 'hidden'
+      visibility: this.props.show && this.props.isMainView ? 'visible' : 'hidden'
     }
 
     const shadowStyle: CSSProperties = {
@@ -1172,6 +1190,8 @@ const mapStateToProps = (state) => ({
   firstDot: state.gesture.doubleTap.firstDot,
   leftToRightDiagonal: state.gesture.crossLine.leftToRightDiagonal,
   rightToLeftDiagonal: state.gesture.crossLine.rightToLeftDiagonal,
+  notFirstPenDown: state.gesture.symbol.notFirstPenDown,
+  show: state.gesture.symbol.show,
   hideCanvas: state.gesture.hideCanvas,
   activePageNo: state.activePage.activePageNo
 });
@@ -1184,6 +1204,9 @@ const mapDispatchToProps = (dispatch) => ({
   setLeftToRightDiagonal: () => setLeftToRightDiagonal(),
   setRightToLeftDiagonal: () => setRightToLeftDiagonal(),
   initializeCrossLine: () => initializeCrossLine(),
+  setNotFirstPenDown: () => setNotFirstPenDown(),
+  showSymbol: () => showSymbol(),
+  hideSymbol: () => hideSymbol(),
   setHideCanvas: (bool) => setHideCanvas(bool),
   setActivePageNo: no => setActivePageNo(no)
 });

--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -980,7 +980,7 @@ class PenBasedRenderer extends React.Component<Props, State> {
     */
     const shiftArray = ['top', 'left', 'bottom', 'right'];
     const shiftEdgeArray = ['top-left', 'bottom-left', 'bottom-right', 'top-right'];
-    const rotateDegree = this.props.rotation / 90;
+    const rotateDegree = this.getRotationOnPageMode() / 90;
 
     /** Plate의 width, height, gestureArea(짧은면 기준 1/3) */
     const {npaperWidth, npaperHeight, gestureArea} = this.getPaperSize();

--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -530,7 +530,6 @@ class PenBasedRenderer extends React.Component<Props, State> {
   onLivePenDown = (event: IPenToViewerEvent) => {
     if (this.props.hideCanvas) {
       showMessageToast(getText('hide_canvas'));
-      return
     }
     if (this.renderer) {
       // const { section, owner, book, page } = event;

--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -627,8 +627,8 @@ class PenBasedRenderer extends React.Component<Props, State> {
         default:
           return
       }
+      this.removeDoubleTapStrokeOnActivePage(this.renderer.pageInfo);
     }
-    this.removeDoubleTapStrokeOnActivePage(this.renderer.pageInfo);
     this.props.initializeTap();
   }
 

--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -6,7 +6,7 @@ import {Typography} from "@material-ui/core";
 import {IRenderWorkerOption} from "./RenderWorkerBase";
 import PenBasedRenderWorker from "./PenBasedRenderWorker";
 
-import {IBrushType, PageEventName, PenEventName, PLAYSTATE, ZoomFitEnum} from "nl-lib/common/enums";
+import {PageEventName, PenEventName, PLAYSTATE, ZoomFitEnum} from "nl-lib/common/enums";
 import {IPageSOBP, ISize, NeoDot, NeoStroke} from "nl-lib/common/structures";
 import {callstackDepth, isSameNcode, isSamePage, makeNPageIdStr, uuidv4} from "nl-lib/common/util";
 
@@ -19,7 +19,7 @@ import {isPlatePaper, isPUI, getNPaperInfo, adjustNoteItemMarginForFilm} from "n
 import {setCalibrationData} from 'GridaBoard/store/reducers/calibrationDataReducer';
 import {store} from "GridaBoard/client/pages/GridaBoard";
 import GridaDoc from "GridaBoard/GridaDoc";
-import { initializeDiagonal, setLeftToRightDiagonal, setRightToLeftDiagonal, setHideCanvas, incrementTapCount, initializeTapCount, setFirstTap } from "GridaBoard/store/reducers/gestureReducer";
+import { initializeCrossLine, setLeftToRightDiagonal, setRightToLeftDiagonal, setHideCanvas, incrementTapCount, initializeTap, setFirstDot } from "GridaBoard/store/reducers/gestureReducer";
 import { setActivePageNo } from "GridaBoard/store/reducers/activePageReducer";
 import { onToggleRotate } from "GridaBoard/components/buttons/RotateButton";
 import { showMessageToast } from "GridaBoard/store/reducers/ui";
@@ -82,10 +82,10 @@ interface Props { // extends MixedViewProps {
   tapCount: number;
   firstDot: NeoDot;
   incrementTapCount: any;
-  initializeTapCount: any;
-  setFirstTap: any;
+  initializeTap: any;
+  setFirstDot: any;
 
-  initializeDiagonal: any;
+  initializeCrossLine: any;
   leftToRightDiagonal: boolean;
   rightToLeftDiagonal: boolean;
   setLeftToRightDiagonal: any;
@@ -619,7 +619,7 @@ class PenBasedRenderer extends React.Component<Props, State> {
       }
     }
     this.removeDoubleTapStrokeOnActivePage(this.renderer.pageInfo);
-    this.props.initializeTapCount();
+    this.props.initializeTap();
   }
 
   /**
@@ -638,12 +638,12 @@ class PenBasedRenderer extends React.Component<Props, State> {
 
     if (this.isTap(timeDiff, distance)) {
       if (!this.props.firstDot) {
-        this.props.setFirstTap(first);
+        this.props.setFirstDot(first);
         return true
       }
       return this.isNotFirstTap(first);
     }
-    this.props.initializeTapCount();
+    this.props.initializeTap();
     return false
   }
 
@@ -666,7 +666,7 @@ class PenBasedRenderer extends React.Component<Props, State> {
       return true
     }
 
-    this.props.setFirstTap(first);
+    this.props.setFirstDot(first);
     return false
   }
 
@@ -746,7 +746,7 @@ class PenBasedRenderer extends React.Component<Props, State> {
     
     if (this.props.leftToRightDiagonal && this.props.rightToLeftDiagonal) {
       onClearPage();
-      this.props.initializeDiagonal();
+      this.props.initializeCrossLine();
     }
   }
 
@@ -1179,11 +1179,11 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch) => ({
   setCalibrationData: cali => setCalibrationData(cali),
   incrementTapCount: () => incrementTapCount(),
-  initializeTapCount: () => initializeTapCount(),
-  setFirstTap: (dot) => setFirstTap(dot),
+  initializeTap: () => initializeTap(),
+  setFirstDot: (dot) => setFirstDot(dot),
   setLeftToRightDiagonal: () => setLeftToRightDiagonal(),
   setRightToLeftDiagonal: () => setRightToLeftDiagonal(),
-  initializeDiagonal: () => initializeDiagonal(),
+  initializeCrossLine: () => initializeCrossLine(),
   setHideCanvas: (bool) => setHideCanvas(bool),
   setActivePageNo: no => setActivePageNo(no)
 });

--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -1075,6 +1075,10 @@ class PenBasedRenderer extends React.Component<Props, State> {
     return {npaperWidth, npaperHeight, gestureArea}
   }
 
+  /** 페이지 mode(landscape/portrait)에 따른 회전값을 가져오기 위한 함수 
+   * landscape: 현재 rotation 값을 그대로 가져옴
+   * portrait: landscape에서 90도 회전된 상태의 값을 주어야 하므로 현재 rotation 값에 90을 더해준다.
+  */
   getRotationOnPageMode = () => {
     const currentPage = GridaDoc.getInstance().getPage(store.getState().activePage.activePageNo);
     if (!currentPage) return

--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -363,7 +363,6 @@ class PenBasedRenderer extends React.Component<Props, State> {
     if ((this.props.rotation !== nextProps.rotation) && isSamePage(this.props.basePageInfo, nextProps.basePageInfo)) {
       //회전 버튼을 누를 경우만 들어와야 하는 로직, 회전된 pdf를 로드할 때는 들어오면 안됨
       //로드할 경우에는 this.props의 basePageInfo가 nullNCode로 세팅돼있기 때문에 들어오지 않음
-      this.props.setNotFirstPenDown(false);
       this.renderer.setRotation(nextProps.rotation, this.pdfSize);
 
       // const ctx = this.canvas.getContext('2d');

--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -14,7 +14,7 @@ import {INeoSmartpen, IPenToViewerEvent} from "nl-lib/common/neopen";
 import {MappingStorage} from "nl-lib/common/mapper";
 import {DefaultPlateNcode, DefaultPUINcode} from "nl-lib/common/constants";
 import {InkStorage} from "nl-lib/common/penstorage";
-import {isPlatePaper, isPUI, getNPaperInfo} from "nl-lib/common/noteserver";
+import {isPlatePaper, isPUI, getNPaperInfo, adjustNoteItemMarginForFilm} from "nl-lib/common/noteserver";
 
 import {setCalibrationData} from 'GridaBoard/store/reducers/calibrationDataReducer';
 import {store} from "GridaBoard/client/pages/GridaBoard";
@@ -26,6 +26,7 @@ import { showMessageToast } from "GridaBoard/store/reducers/ui";
 import getText from "GridaBoard/language/language";
 import { onClearPage } from "boardList/layout/component/dialog/detail/AlertDialog";
 import Add from "@material-ui/icons/Add";
+
 
 /**
  * Properties
@@ -1055,6 +1056,7 @@ class PenBasedRenderer extends React.Component<Props, State> {
   getPaperSize = () => {
     // plate일 때, 해당 plate의 info를 가져옴.
     const noteItem = getNPaperInfo(this.props.pageInfo);
+    adjustNoteItemMarginForFilm(noteItem, this.props.pageInfo);
     const npaperWidth = noteItem.margin.Xmax - noteItem.margin.Xmin;
     const npaperHeight = noteItem.margin.Ymax - noteItem.margin.Ymin;
 

--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -1066,6 +1066,18 @@ class PenBasedRenderer extends React.Component<Props, State> {
     return {npaperWidth, npaperHeight, gestureArea}
   }
 
+  getRotationOnPageMode = () => {
+    const currentPage = GridaDoc.getInstance().getPage(store.getState().activePage.activePageNo);
+    if (!currentPage) return
+    
+    let pageMode = "portrait";
+    if (currentPage.pageOverview.landscape) {
+      pageMode = "landscape";
+    }
+    
+    return pageMode === "portrait" ? (this.props.rotation+90)%360 : this.props.rotation 
+  }
+
   render() {
     let { zoom } = this.props.position;
 
@@ -1091,10 +1103,10 @@ class PenBasedRenderer extends React.Component<Props, State> {
 
     const symbolDiv: CSSProperties = {
       position: "absolute",
-      left: ([0, 270]).includes(this.props.rotation) ? 5 : "",
-      right: ([90, 180]).includes(this.props.rotation) ? 5 : "",
-      top: ([0, 90]).includes(this.props.rotation) ? 5 : "",
-      bottom: ([180, 270]).includes(this.props.rotation) ? 5 : "",
+      left: ([0, 270]).includes(this.getRotationOnPageMode()) ? 5 : "",
+      right: ([90, 180]).includes(this.getRotationOnPageMode()) ? 5 : "",
+      top: ([0, 90]).includes(this.getRotationOnPageMode()) ? 5 : "",
+      bottom: ([180, 270]).includes(this.getRotationOnPageMode()) ? 5 : "",
       zIndex: 11,
     }
 

--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -591,7 +591,6 @@ class PenBasedRenderer extends React.Component<Props, State> {
 
   /** Touble tap process */
   doubleTapProcess = (isPlate: boolean, dot: NeoDot) => {
-    this.removeDoubleTapStrokeOnActivePage(this.renderer.pageInfo);
     // plate에서 작업하는 중에 발생하는 double tap 처리를 영역별로 구분
     if (isPlate) {
       switch(this.findDotPositionOnPlate(dot)) {
@@ -615,8 +614,11 @@ class PenBasedRenderer extends React.Component<Props, State> {
             this.plusControlZone();
           }
           break;
+        default:
+          return
       }
     }
+    this.removeDoubleTapStrokeOnActivePage(this.renderer.pageInfo);
     this.props.initializeTapCount();
   }
 


### PR DESCRIPTION
부기보드의 '세로모드 사용' -> '가로모드 사용'으로 변경됨에 따라 관련 코드들 업데이트

[업데이트]
1. page mode를 구별하여 rotation을 적용하도록 함. (landscape <-> portrait)
2. Symbol을 위한 reducer 정의

[수정사항]
1. tap stroke가 gesture 가능영역에서만 지워지고 그 외의 영역에서는 지워지지 않도록 수정
2. hide 모드일때 createLiveStroke가 생성되기 전에 함수를 종료시켜 pathObj가 생성되지 않고 이로인해 발생하는 오류 수정
3. 2. gesture reducer 함수들의 리팩토링

[진행사항]
1. symbol 표시를 담당하는 로직 개선중