### PR TITLE
[Feat] Plate 1, 2를 이용한 새 페이지 생성 시의 로직

### DIFF
--- a/src/GridaBoard/GridaApp.ts
+++ b/src/GridaBoard/GridaApp.ts
@@ -75,7 +75,9 @@ export default class GridaApp {
 
     const pageInfo = { section: event.section, owner: event.owner, book: event.book, page: event.page } as IPageSOBP;
 
-    if (isSameNcode(pageInfo, DefaultPlateNcode) || isSameNcode(pageInfo, DefaultPUINcode) || isPUI(pageInfo)) {
+    const numDocPages = store.getState().activePage.numDocPages
+
+    if (isSameNcode(pageInfo, DefaultPlateNcode) && numDocPages !== 0 || isSameNcode(pageInfo, DefaultPUINcode) || isPUI(pageInfo)) {
         return;
     }
 
@@ -117,4 +119,3 @@ export default class GridaApp {
     }
   }
 }
-

--- a/src/GridaBoard/GridaDoc.ts
+++ b/src/GridaBoard/GridaDoc.ts
@@ -378,6 +378,7 @@ export default class GridaDoc {
 
         case "note":
         case "default":
+        case "plate":
         default: {
           //
           const activePageNo = this.addNcodePage(pageInfo);

--- a/src/GridaBoard/Layout/HeaderLayer.tsx
+++ b/src/GridaBoard/Layout/HeaderLayer.tsx
@@ -26,6 +26,9 @@ import { auth, firebaseAnalytics } from 'GridaBoard/util/firebase_config';
 import ProfileButton from '../components/buttons/ProfileButton';
 import { showAlert } from '../store/reducers/listReducer';
 import { setSaveOpen } from '../store/reducers/ui';
+import { store } from '../client/pages/GridaBoard';
+import { resetGridaBoard, saveThumbnail } from '../../boardList/BoardListPageFunc';
+import { setIsNewDoc } from '../store/reducers/docConfigReducer';
 
 const useStyles = props =>
   makeStyles(theme => ({
@@ -179,12 +182,29 @@ interface Props {
 
 export function fileOpenHandler(dndData: any) {
   const input = document.querySelector('#fileForconvert') as HTMLInputElement;
+
+  const isNewDoc = store.getState().docConfig.isNewDoc;
+  const numDocPages = store.getState().activePage.numDocPages;
+  const autoSaveTitle = "undefined"
+  
   if(dndData === ""){
     input.value = '';
     input.click();
   }else{
     input.files = dndData;
-    input.dispatchEvent(new Event("change", {bubbles: true}));
+    if(isNewDoc && numDocPages !== 0){
+      setIsNewDoc(false);
+      saveThumbnail(autoSaveTitle)
+      const timer = setInterval(() => 
+      {
+        resetGridaBoard()
+        input.dispatchEvent(new Event("change", {bubbles: true}))
+        clearInterval(timer);
+      }
+      , 3000);
+    }else{
+      input.dispatchEvent(new Event("change", {bubbles: true}));
+    }
   }
 }
 
@@ -387,7 +407,7 @@ const HeaderLayer = (props: Props) => {
                     className={`loadDropDown ${classes.buttonStyle} ${classes.buttonFontStyle}`}
                     onClick={e =>  fileOpenHandler("")}>
                     {getText('load_file')}
-                    <ConvertFileLoad handlePdfOpen={handlePdfOpen} />
+                    <ConvertFileLoad handlePdfOpen={handlePdfOpen} isNewLoad={true}/>
                   </Button>
                 </CustomBadge>
               </div>

--- a/src/GridaBoard/Layout/LeftSideLayer.tsx
+++ b/src/GridaBoard/Layout/LeftSideLayer.tsx
@@ -111,7 +111,6 @@ const LeftSideLayer = (props: Props) => {
   const handleDrop = useCallback((e) => {
     console.log("Drop to Layer")
     dragRef.current.style.background = "rgba(0,0,0,0)"
-    // resetGridaBoard();
     fileOpenHandler(e.dataTransfer.files)
     e.preventDefault();
     e.stopPropagation();

--- a/src/GridaBoard/Save/SavePdf.tsx
+++ b/src/GridaBoard/Save/SavePdf.tsx
@@ -4,11 +4,12 @@ import { degrees, PDFDocument, PDFPage, rgb, StandardFonts } from 'pdf-lib';
 import GridaDoc from "../GridaDoc";
 
 import { InkStorage } from "nl-lib/common/penstorage";
-import { drawPath } from "nl-lib/common/util";
+import { drawPath, isSamePage } from "nl-lib/common/util";
 import { adjustNoteItemMarginForFilm, getNPaperInfo } from "../../nl-lib/common/noteserver";
 import { store } from "../client/pages/GridaBoard";
 import { NeoStroke } from "../../nl-lib/common/structures";
 import { firebaseAnalytics } from "../util/firebase_config";
+import { PlateNcode_1, PlateNcode_2 } from "../../nl-lib/common/constants";
 
 const PDF_TO_SCREEN_SCALE = 6.72; // (56/600)*72
 
@@ -61,7 +62,7 @@ export async function makePdfDocument() {
         pdfDoc = await PDFDocument.create();
       }
       const pdfPage = await pdfDoc.addPage();
-      if (page._rotation === 90 || page._rotation === 270) {
+      if (page._rotation === 90 || page._rotation === 270 || isSamePage(page.pageInfos[0], PlateNcode_2) || isSamePage(page.pageInfos[0], PlateNcode_1)) {
         const tmpWidth = pdfPage.getWidth();
         pdfPage.setWidth(pdfPage.getHeight());
         pdfPage.setHeight(tmpWidth);

--- a/src/boardList/layout/MainContent.tsx
+++ b/src/boardList/layout/MainContent.tsx
@@ -14,6 +14,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../GridaBoard/store/rootReducer';
 import { showSnackbar } from '../../GridaBoard/store/reducers/listReducer';
 import { store } from "GridaBoard/client/pages/GridaBoard";
+import { setActivePageNo } from '../../GridaBoard/store/reducers/activePageReducer';
 
 const useStyle = makeStyles(theme => ({
   wrap: {
@@ -316,6 +317,10 @@ const MainContent = (props: Props) => {
     setSelectedItems([]);
     setAllItemsChecked(false);
   }, [docs, selected]);
+
+  useEffect(() => {
+    setActivePageNo(0);
+  }, [])
 
   const getNowDocs = () => {
     let tmpDocs = [];

--- a/src/nl-lib/common/noteserver/SurfaceInfo.ts
+++ b/src/nl-lib/common/noteserver/SurfaceInfo.ts
@@ -1,6 +1,6 @@
 import { g_paperType } from "./NcodeSurfaceDataJson";
 import { INcodeSOBPxy, INoteServerItem_forPOD, IPageSOBP, IPaperSize, ISize } from "../structures";
-import { FilmNcode_Landscape, FilmNcode_Portrait, INCH_TO_MM_SCALE, NCODE_TO_INCH_SCALE, PDF_DEFAULT_DPI, PlateNcode_3, UNIT_TO_DPI } from "../constants";
+import { FilmNcode_Landscape, FilmNcode_Portrait, INCH_TO_MM_SCALE, NCODE_TO_INCH_SCALE, PDF_DEFAULT_DPI, PlateNcode_3, PlateNcode_2, PlateNcode_1, UNIT_TO_DPI } from "../constants";
 import { isSamePage } from "../util";
 
 
@@ -59,21 +59,14 @@ export function isPUI(pageInfo: IPageSOBP): boolean {
 function getNPaperSize_nu(item: IPageSOBP | INoteServerItem_forPOD): ISize {
   let desc = item as INoteServerItem_forPOD;
 
-  const pageInfo = item as IPageSOBP;
   // IPageSOBP 이면 noteserver item을 가져 온다.
   if (!Object.prototype.hasOwnProperty.call(item, "margin")) {
+    const pageInfo = item as IPageSOBP;
     desc = getNPaperInfo(pageInfo);
   }
 
   const margin = desc.margin;
 
-  // 플레이트 시 가로형 A4 생성
-  if(isPlatePaper(pageInfo)){
-    margin.Xmax = 125.24;
-    margin.Xmin = 0;
-    margin.Ymax = 88.56;
-    margin.Ymin = 0;
-  }
 
   return {
     width: margin.Xmax - margin.Xmin,
@@ -158,6 +151,12 @@ export function adjustNoteItemMarginForFilm(noteItem: INoteServerItem_forPOD, pa
     noteItem.margin.Ymin = 0;
     noteItem.margin.Xmax = 55;
     noteItem.margin.Ymax = 77;
+  }
+  else if(isSamePage(pageInfo, PlateNcode_2) || isSamePage(pageInfo, PlateNcode_1)){
+    noteItem.margin.Xmax = 125.24;
+    noteItem.margin.Ymax = 88.56;
+    noteItem.margin.Xmin = 0;
+    noteItem.margin.Ymin = 0;
   }
 }
 

--- a/src/nl-lib/common/noteserver/SurfaceInfo.ts
+++ b/src/nl-lib/common/noteserver/SurfaceInfo.ts
@@ -59,13 +59,22 @@ export function isPUI(pageInfo: IPageSOBP): boolean {
 function getNPaperSize_nu(item: IPageSOBP | INoteServerItem_forPOD): ISize {
   let desc = item as INoteServerItem_forPOD;
 
+  const pageInfo = item as IPageSOBP;
   // IPageSOBP 이면 noteserver item을 가져 온다.
   if (!Object.prototype.hasOwnProperty.call(item, "margin")) {
-    const pageInfo = item as IPageSOBP;
     desc = getNPaperInfo(pageInfo);
   }
 
   const margin = desc.margin;
+
+  // 플레이트 시 가로형 A4 생성
+  if(isPlatePaper(pageInfo)){
+    margin.Xmax = 125.24;
+    margin.Xmin = 0;
+    margin.Ymax = 88.56;
+    margin.Ymin = 0;
+  }
+
   return {
     width: margin.Xmax - margin.Xmin,
     height: margin.Ymax - margin.Ymin
@@ -211,5 +220,3 @@ export function isPortrait(size: ISize) {
 export function getCssDpi() {
   return UNIT_TO_DPI["css"];
 }
-
-

--- a/src/nl-lib/common/penstorage/InkStorage.ts
+++ b/src/nl-lib/common/penstorage/InkStorage.ts
@@ -176,10 +176,11 @@ export default class InkStorage {
 
     const activePageNo = store.getState().activePage.activePageNo;
 
-    if ((isPlatePaper(pageInfo) || isPUI(pageInfo)) && activePageNo === -1) {
-      if (isPlatePaper(pageInfo)) {
-        alert(getText("alert_needPage"));
-      }
+    // if ((isPlatePaper(pageInfo) || isPUI(pageInfo)) && activePageNo === -1) {
+    if ((isPUI(pageInfo)) && activePageNo === -1) {
+      // if (isPlatePaper(pageInfo)) {
+      //   alert(getText("alert_needPage"));
+      // }
       return;
     }
 

--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -414,9 +414,14 @@ class PenBasedRenderer extends React.Component<Props, State> {
 
         this.renderer._opt.rotation = nextProps.rotation;
         
-        // if (isSameNcode(nextProps.pageInfo, DefaultPlateNcode)){
-        //   return;
-        // }
+        const doc = GridaDoc.getInstance();
+        const page = doc.getPageAt(0);
+        if(doc.pages.length !== 0){
+          const isPdf = page.pdf
+          if (isSameNcode(nextProps.pageInfo, DefaultPlateNcode) && isPdf !== undefined && nextProps.pdfSize.height > nextProps.pdfSize.width){
+            return;
+          }
+        }
         const transform = MappingStorage.getInstance().getNPageTransform(pageInfo);
         this.renderer.setTransformParameters(transform.h, this.pdfSize);
 

--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -414,9 +414,9 @@ class PenBasedRenderer extends React.Component<Props, State> {
 
         this.renderer._opt.rotation = nextProps.rotation;
         
-        if (isSameNcode(nextProps.pageInfo, DefaultPlateNcode)){
-          return;
-        }
+        // if (isSameNcode(nextProps.pageInfo, DefaultPlateNcode)){
+        //   return;
+        // }
         const transform = MappingStorage.getInstance().getNPageTransform(pageInfo);
         this.renderer.setTransformParameters(transform.h, this.pdfSize);
 


### PR DESCRIPTION
Feat: 최초화면 (대기화면) 일 때 Plate 터치 시 가로형 A4가 생성
Feat: 가로형 A4 생성위한 plate1, plate2 분기 추가
Feat: 가로형 plate 이용하여 페이지 생성 시 렌더링 진입하도록 분기 변경
 - 최초화면에서 plate 터치 시 가로형 빈 A4 생성 후 스트로크 작성

Feat: pdf 저장 시 가로형 plate일 경우 W, H 스위칭
 - pdf 저장 시 plate일 경우 너비와 높이 스위칭

Feat: DnD, 파일 불러오기 시 어노테이션, 프리핸드 구별
 - 어노테이션 상태일 경우, 가장 마지막 페이지에 붙어 페이지 생성
 - 프리핸드 상태일 경우, 자동 저장 후 불러오는 페이지로 전환

Fix: 메인 페이지 이동 시 activePageNo 0로 설정
 - 페이지 생성 또는 로드 후 새 페이지를 생성할 경우 해당 페이지로 스크롤이 자동이동되며,
   setActivePageNo 호출하여 페이지 값 변경하는데, 이후 메인화면으로 이동 시에도 해당 값이 남아
   activePage 값이 적은 데이터를 로드하거나 빈 페이지를 생성할 경우 _pdfPage가 undefined되는 이슈 수정





