### PR TITLE
[Fix, Feat] _pdfSize 이슈, 방향키 이동 로직 처리

### DIFF
--- a/src/GridaBoard/KeyBoardShortCut.ts
+++ b/src/GridaBoard/KeyBoardShortCut.ts
@@ -17,6 +17,7 @@ import { setleftDrawerOpen, setSaveOpen, showShortCut } from './store/reducers/u
 import { onToggleRotate } from "./components/buttons/RotateButton";
 import { fileOpenHandler } from "./Layout/HeaderLayer";
 import { startPrint } from "../nl-lib/ncodepod/NcodePrint/PrintNcodedPdfButton";
+import { scrollToThumbnail } from "../nl-lib/common/util/functions";
 
 /* 
 let _isCtrl = false;
@@ -213,6 +214,7 @@ export default function KeyBoardShortCut(evt: KeyboardEvent) {
           return;
         }
         setActivePageNo(activePageNo-1);
+        scrollToThumbnail(activePageNo-1);
         break;
       }
       // page down
@@ -228,6 +230,7 @@ export default function KeyBoardShortCut(evt: KeyboardEvent) {
           return;
         }
         setActivePageNo(activePageNo+1);
+        scrollToThumbnail(activePageNo+1);
         break;
       }
 

--- a/src/boardList/layout/MainContent.tsx
+++ b/src/boardList/layout/MainContent.tsx
@@ -1,5 +1,5 @@
 import { Button, Checkbox, makeStyles, Snackbar, SnackbarContent, Slide } from '@material-ui/core';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import getText from 'GridaBoard/language/language';
 import MainNavSelector from './component/mainContent/MainNavSelector';
 import MainNewButton from './component/mainContent/MainNewButton';
@@ -14,6 +14,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../GridaBoard/store/rootReducer';
 import { showSnackbar } from '../../GridaBoard/store/reducers/listReducer';
 import { store } from "GridaBoard/client/pages/GridaBoard";
+import { setActivePageNo } from '../../GridaBoard/store/reducers/activePageReducer';
 
 const useStyle = makeStyles(theme => ({
   wrap: {
@@ -317,6 +318,10 @@ const MainContent = (props: Props) => {
     setAllItemsChecked(false);
   }, [docs, selected]);
 
+  useEffect(() => {
+    setActivePageNo(0)
+  }, [])
+  
   const getNowDocs = () => {
     let tmpDocs = [];
     if (['recent', 'trash'].includes(selected)) {


### PR DESCRIPTION
Fix: 메인 페이지 이동 시 activePageNo 0로 설정
 - 페이지 생성 또는 로드 후 새 페이지를 생성할 경우 해당 페이지로 스크롤이 자동이동되며,
setActivePageNo 호출하여 페이지 값 변경하는데, 이후 메인화면으로 이동 시에도 해당 값이 남아
activePage 값이 적은 데이터를 로드하거나 빈 페이지를 생성할 경우 _pdfPage가 undefined되는 이슈 수정

Feat: 방향키 사용하여 페이지 이동 시 썸네일도 이동하도록 설정
 - 방향키 사용하여 페이지 이동 시 썸네일, 스크롤도 같이 이동