### PR TITLE
[Fix, Feat] _pdfSize 이슈, 방향키 이동 로직 처리

### DIFF
--- a/src/GridaBoard/KeyBoardShortCut.ts
+++ b/src/GridaBoard/KeyBoardShortCut.ts
@@ -17,6 +17,7 @@ import { setleftDrawerOpen, setSaveOpen, showShortCut } from './store/reducers/u
 import { onToggleRotate } from "./components/buttons/RotateButton";
 import { fileOpenHandler } from "./Layout/HeaderLayer";
 import { startPrint } from "../nl-lib/ncodepod/NcodePrint/PrintNcodedPdfButton";
+import { scrollToThumbnail } from "../nl-lib/common/util/functions";
 
 /* 
 let _isCtrl = false;
@@ -213,6 +214,7 @@ export default function KeyBoardShortCut(evt: KeyboardEvent) {
           return;
         }
         setActivePageNo(activePageNo-1);
+        scrollToThumbnail(activePageNo-1);
         break;
       }
       // page down
@@ -228,6 +230,7 @@ export default function KeyBoardShortCut(evt: KeyboardEvent) {
           return;
         }
         setActivePageNo(activePageNo+1);
+        scrollToThumbnail(activePageNo+1);
         break;
       }
 

--- a/src/boardList/BoardList.tsx
+++ b/src/boardList/BoardList.tsx
@@ -20,7 +20,7 @@ import CombineDialog from './layout/component/dialog/CombineDialog';
 import { getCategoryArray } from "./BoardListPageFunc2";
 import GlobalDropdown from './layout/component/GlobalDropdown';
 import { setDefaultCategory, getDatabase } from "./BoardListPageFunc2"
-import { getTimeStamp } from './BoardListPageFunc';
+import { getTimeStamp, resetGridaBoard } from './BoardListPageFunc';
 import LoadingCircle from "GridaBoard/Load/LoadingCircle";
 import { setLoadingVisibility } from 'GridaBoard/store/reducers/loadingCircle'
 import { forceUpdateBoardList } from '../GridaBoard/store/reducers/appConfigReducer';
@@ -140,6 +140,7 @@ const BoardList = () => {
  
 
   const routeChange = async idx => {
+    await resetGridaBoard();
     const nowDocs = docsObj.docs[idx];
     if (nowDocs.dateDeleted !== 0) {
       return;


### PR DESCRIPTION
Fix: 파일 로드 시 그리다보드 리셋하도록 설정
 - 페이지 생성 또는 로드 후 새 페이지를 생성할 경우 해당 페이지로 스크롤이 자동이동되며,
 setActivePageNo 호출하여 페이지 값 변경하는데, 이후 메인화면으로 이동 시에도 해당 값이 남아
 activePage 값이 적은 데이터를 로드하거나 빈 페이지를 생성할 경우 _pdfPage가 undefined되는 이슈 수정

Feat: 방향키 사용하여 페이지 이동 시 썸네일도 이동하도록 설정
 - 방향키 사용하여 페이지 이동 시 썸네일, 스크롤도 같이 이동