### PR TITLE
[버그] 버튼으로 '필기 숨기기' 해제시 정상적으로 동작하지 않던 문제

### DIFF
--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -480,9 +480,7 @@ class PenBasedRenderer extends React.Component<Props, State> {
       }
     }
 
-    if (this.props.hideCanvasMode !== nextProps.hideCanvasMode) {
-      if (!this.props.isMainView) return
-      
+    if (this.props.hideCanvasMode !== nextProps.hideCanvasMode && this.props.isMainView) {
       if (nextProps.hideCanvasMode) {
         this.renderer.removeAllCanvasObject();  
       } else {

--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -480,10 +480,14 @@ class PenBasedRenderer extends React.Component<Props, State> {
       }
     }
 
-    if (this.props.hideCanvasMode && this.props.isMainView) {
-      this.renderer.removeAllCanvasObject();
-    } else {
-      this.renderer.redrawStrokes(nextProps.pageInfo);
+    if (this.props.hideCanvasMode !== nextProps.hideCanvasMode) {
+      if (!this.props.isMainView) return
+      
+      if (nextProps.hideCanvasMode) {
+        this.renderer.removeAllCanvasObject();  
+      } else {
+        this.renderer.redrawStrokes(this.renderer.pageInfo);
+      }
     }
   
     return ret_val;


### PR DESCRIPTION
현상: gesture로 필기를 숨긴 후 '필기 숨기기' 버튼으로 해제시 redraw가 안되던 현상
해결: redrawStroke를 하는 로직안에 pageInfo를 비교하는 구문이 있는데, 버튼으로 '필기 숨기기' 해제를 한 뒤에  pageInfo의 옳은 값이 넘어가지 않아서 발생. 따라서, 현재 rendering되고 있는 pageInfo의 값을 넘겨주기 위해 props의 pageInfo 값이 아닌 renderer의 pageInfo의 값을 넘겨준다.

