### PR TITLE
[버그] gesture 기능을 수행할 때 발생되는 버그 수정

### DIFF
--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -480,10 +480,11 @@ class PenBasedRenderer extends React.Component<Props, State> {
       }
     }
 
-    if (this.props.hideCanvasMode !== nextProps.hideCanvasMode && this.props.isMainView) {
+    // hideCanvasMode 상태에 따른 로직 처리
+    if (this.props.isMainView) { // 메인 뷰의 화면만 처리해준다. (thumbnail 제외)
       if (nextProps.hideCanvasMode) {
-        this.renderer.removeAllCanvasObject();  
-      } else {
+        this.renderer.removeAllCanvasObject(); // hideCanvasMode true 일 때, 계속 삭제해준다. -> 페이지 이동같은 event일때도 처리를 해줘야 하므로,
+      } else if (this.props.hideCanvasMode !== nextProps.hideCanvasMode) { // false 이고 hideCanvasMode 상태가 바뀔 때, redraw 해준다.
         this.renderer.redrawStrokes(this.renderer.pageInfo);
       }
     }

--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -623,6 +623,7 @@ class PenBasedRenderer extends React.Component<Props, State> {
 
   /** Touble tap process */
   doubleTapProcess = (isPlate: boolean, dot: NeoDot) => {
+    const pageInfo = this.renderer.pageInfo;
     // plate에서 작업하는 중에 발생하는 double tap 처리를 영역별로 구분
     if (isPlate) {
       switch(this.findDotPositionOnPlate(dot)) {
@@ -649,7 +650,7 @@ class PenBasedRenderer extends React.Component<Props, State> {
         default:
           return
       }
-      this.removeDoubleTapStrokeOnActivePage(this.renderer.pageInfo);
+      this.removeDoubleTapStrokeOnActivePage(pageInfo);
     }
     this.props.initializeTap();
   }
@@ -927,13 +928,13 @@ class PenBasedRenderer extends React.Component<Props, State> {
     // hideCanvas가 되어있을시 redraw 로직을 실행하면 다시 stroke가 생성되므로 로직이 실행되지 않도록 함수를 종료시켜준다. 
     if (this.props.hideCanvasMode) return
     this.renderer.redrawStrokes(pageInfo);
-
+    
     // Thumbnail 영역 redraw 를 위한 dispath 추가
     this.renderer.storage.dispatcher.dispatch(PenEventName.ON_ERASER_MOVE, {
-      section: this.renderer.pageInfo.section,
-      owner: this.renderer.pageInfo.owner,
-      book: this.renderer.pageInfo.book,
-      page: this.renderer.pageInfo.page,
+      section: pageInfo.section,
+      owner: pageInfo.owner,
+      book: pageInfo.book,
+      page: pageInfo.page,
     });
   }
 


### PR DESCRIPTION
문제 1. hideCanvasMode 상태에서 페이지 이동을 했을때, canvas가 사라지지 않는 현상(stroke가 다 보임)
- shouldComponentUpdate에서 hideCanvasMode 의 상태가 바뀔때만 해당 로직을 실행하기 때문에 페이지 이동과 같은 상태의 변화에서는 hideCanvasMode 로직이 실행되지 않음. 따라서, 조건을 변경하여 hideCanvasMode일때는 계속 지워주고, hideCanvasMode의 상태 false 로 변할때만 redraw 시켜준다.

문제 2. double tap stroke를 지워주는 로직에서 pageInfo를 잘못 넘겨주고 있던 버그
- double tap stroke를 지워주는 로직은 해당 제스처 로직을 다 끝낸 후 들어오게 된다. 문제는 페이지 이동이 됐을때 this.renderer.pageInfo와 같은 형태로 넘겨주면 탭을 지워주는 로직에서는 이동된 페이지의 pageInfo를 받게되는 것이다. 따라서, 제스처 로직이 발생되기 전의 pageInfo를 const로 선언하고 이 값을 넘겨주어 해결한다.