### PR TITLE
[Fix] 펜 제스처로 페이지 이동 시 스크롤 이동, 썸네일 중앙 배열

### DIFF
--- a/src/nl-lib/common/util/functions.ts
+++ b/src/nl-lib/common/util/functions.ts
@@ -465,7 +465,7 @@ export function scrollToBottom(id: string) {
 
 export function scrollToThumbnail(pageNo : Number){
   const ele = document.getElementById("thumbnail - " + pageNo + " -mixed_view");
-  (ele) ? ele.scrollIntoView({behavior: "smooth"}) : null;
+  (ele) ? ele.scrollIntoView({behavior: "smooth", block: "center"}) : null;
 }
 
 

--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -8,7 +8,7 @@ import PenBasedRenderWorker from "./PenBasedRenderWorker";
 
 import {PageEventName, PenEventName, PLAYSTATE, ZoomFitEnum} from "nl-lib/common/enums";
 import {IPageSOBP, ISize, NeoDot, NeoStroke} from "nl-lib/common/structures";
-import {callstackDepth, isSameNcode, isSamePage, makeNPageIdStr, uuidv4} from "nl-lib/common/util";
+import {callstackDepth, isSameNcode, isSamePage, makeNPageIdStr, scrollToThumbnail, uuidv4} from "nl-lib/common/util";
 
 import {INeoSmartpen, IPenToViewerEvent} from "nl-lib/common/neopen";
 import {MappingStorage} from "nl-lib/common/mapper";
@@ -980,12 +980,14 @@ class PenBasedRenderer extends React.Component<Props, State> {
       return showMessageToast(getText('no_more_page'));
     }
     setActivePageNo(this.props.activePageNo-1);    
+    scrollToThumbnail(this.props.activePageNo-1);
   }
   nextChange = () => { // PageDown
     if (this.props.activePageNo === this.state.numDocPages-1) {
       return showMessageToast(getText('no_more_page'));
     }
     setActivePageNo(this.props.activePageNo+1);
+    scrollToThumbnail(this.props.activePageNo+1);
   }
 
 


### PR DESCRIPTION
Fix: 펜 제스처로 페이지 이동 시 스크롤 이동, 썸네일 중앙 배열
 - 펜 제스처로 상 하 이동 시 스크롤도 같이 이동하도록 변경
 - 페이지 이동 시 썸네일은 중앙에 배치되도록 변경