### PR TITLE
[버그수정] 필기 숨기기 버튼, 중복 로직 제거

### DIFF
--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -12,7 +12,7 @@ import {callstackDepth, isSameNcode, isSamePage, makeNPageIdStr, scrollToThumbna
 
 import {INeoSmartpen, IPenToViewerEvent} from "nl-lib/common/neopen";
 import {MappingStorage} from "nl-lib/common/mapper";
-import {DefaultPlateNcode, DefaultPUINcode} from "nl-lib/common/constants";
+import {DefaultPlateNcode, DefaultPUINcode, nullNcode} from "nl-lib/common/constants";
 import {PlateNcode_3} from "nl-lib/common/constants/MapperConstants";
 import {InkStorage} from "nl-lib/common/penstorage";
 import {isPlatePaper, isPUI, getNPaperInfo, adjustNoteItemMarginForFilm} from "nl-lib/common/noteserver";
@@ -484,7 +484,7 @@ class PenBasedRenderer extends React.Component<Props, State> {
     if (this.props.isMainView) { // 메인 뷰의 화면만 처리해준다. (thumbnail 제외)
       if (nextProps.hideCanvasMode) {
         this.renderer.removeAllCanvasObject(); // hideCanvasMode true 일 때, 계속 삭제해준다. -> 페이지 이동같은 event일때도 처리를 해줘야 하므로,
-      } else if (this.props.hideCanvasMode !== nextProps.hideCanvasMode) { // false 이고 hideCanvasMode 상태가 바뀔 때, redraw 해준다.
+      } else if (this.props.hideCanvasMode !== nextProps.hideCanvasMode && !isSamePage(pageInfo, nullNcode())) { // false 이고 hideCanvasMode 상태가 바뀔 때, redraw 해준다.
         this.renderer.redrawStrokes(this.renderer.pageInfo);
       }
     }

--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -927,7 +927,6 @@ class PenBasedRenderer extends React.Component<Props, State> {
 
     // hideCanvas가 되어있을시 redraw 로직을 실행하면 다시 stroke가 생성되므로 로직이 실행되지 않도록 함수를 종료시켜준다. 
     if (this.props.hideCanvasMode) return
-    this.renderer.redrawStrokes(pageInfo);
     
     // Thumbnail 영역 redraw 를 위한 dispath 추가
     this.renderer.storage.dispatcher.dispatch(PenEventName.ON_ERASER_MOVE, {


### PR DESCRIPTION
1. 페이지가 없는 상태에서 '필기숨기기' 버튼 동작시 pageInfo undefined로 발생되는 오류 수정
2. dispath 하는 부분이 redraw를 수행하는 로직이기 때문에 제거한 라인과 중복이 됨. 따라서 제거
