### PR TITLE
#386 - 라이프사이클에 의한 제스처 초기화를 제대로 하지 못해 발생한 버그 수정

### DIFF
--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -543,6 +543,8 @@ class PenBasedRenderer extends React.Component<Props, State> {
       this.inkStorage.removeEventListener(PageEventName.PAGE_CLEAR, this.removeAllCanvasObjectOnActivePage);
       this.inkStorage.removeEventListener(PenEventName.ON_ERASER_MOVE, this.renderer.redrawStrokes);
     }
+    this.props.initializeCrossLine();
+    this.props.initializeTap();
   }
 
   /**


### PR DESCRIPTION
1. 작업페이지에서 제스처와 관련된 동작은 한번 수행한 후 (탭 한번 터치, 대각선 중 하나를 긋기) 그리다보드 홈으로 이동 후 새페이지를 생성한다. 이때, 새페이지에서 이전에 했던 제스처동작을 이어서 할 경우 해당 제스처가 동작한다.
2. component 가 끝날때 제스처를 초기화해주지 못해 발생한 버그