### PR TITLE
#386 - 페이지 이동시 '필기 지우기'를 비롯한 '더블탭' 상태의 초기화가 이루어지지 않아 발생하는 버그 수정

### DIFF
--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -440,8 +440,13 @@ class PenBasedRenderer extends React.Component<Props, State> {
 
         ret_val = true;
 
-        // 페이지 이동했을 때, notFirstPenDown state를 바꿔준다.
+        /** 페이지 이동했을 때, Symbol을 비롯한 제스처 로직들의 초기화가 이루어져야 한다.
+         *  notFirstPenDown - Symbol 첫 touch를 확인하기 위한 state
+         *  & crossLine, doubleTap 관련 state의 초기화
+         * */ 
         this.props.setNotFirstPenDown(false);
+        this.props.initializeCrossLine();
+        this.props.initializeTap();
       }
 
       if (this.props.calibrationMode) {


### PR DESCRIPTION
1. 현재 페이지에서 제스처를 위한 동작 중 하나를 수행하고 다른페이지로 이동해서 나머지 동작을 했을 때 제스처가 정상적으로 동작해버린다. 이를 막기 위해 페이지 이동시에도 제스처 관련 상태의 초기화가 이루어져야 한다.