### PR TITLE
#393 - 플레이트와 노트를 동시에 사용할 때 hover point가 맞지 않는 버그 수정

### DIFF
--- a/src/nl-lib/renderer/penview/PenBasedRenderWorker.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderWorker.tsx
@@ -614,6 +614,8 @@ export default class PenBasedRenderWorker extends RenderWorkerBase {
       pdf_xy = this.ncodeToPdfXy_plate(dot, this.currentPageInfo);
     }
 
+    hps[NUM_HOVER_POINTERS-1].set({ left: pdf_xy.x, top: pdf_xy.y })
+
     // hover point를 쉬프트해서 옮겨 놓는다
     for (let i = NUM_HOVER_POINTERS - 1; i > 0; i--) {
       hps[i].set({ left: hps[i - 1].left, top: hps[i - 1].top });


### PR DESCRIPTION
1. moveHoverPoint 로직에서 처음의 hover point를 변환된 값으로 잡아주지 못해 발생하는 버그이다. 따라서, 처음의 hover point를 변환된 dot의 x, y 값으로 설정해준다.