### PR TITLE
#393 - 플레이트 -> 노트 순으로 필기시 (노트 페이지로 이동 발생) hover point가 맞지 않는 버그 수정

### DIFF
--- a/src/nl-lib/renderer/penview/PenBasedRenderWorker.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderWorker.tsx
@@ -696,6 +696,7 @@ export default class PenBasedRenderWorker extends RenderWorkerBase {
     if (!pageInfo) return;
 
     this.pageInfo = { ...pageInfo };
+    this.currentPageInfo = { ...pageInfo };
 
     const pdfSize = {
       width: Math.round(pageSize.width),


### PR DESCRIPTION
1. 플레이트로 페이지 생성 후 사용
2. 바로 노트를 이용하여 새로운 페이지 생성 후 펜을 사용
3. hover point가 맞지 않음

PenBaseRendererWorker.moveHoverPoint()에서 isPlatePage를 사용하여 현재 작업하는 pageInfo가 플레이트 인지 아닌지를 확인한다.
이때, 위의 순으로 진행시 노트에서 필기 하고 있지만 노트 페이지의 pageInfo가 아니라 플레이트의 pageInfo가 사용되고 있는 것을 확인하였다.
이유는 moveHover안의 isPlatePage()에서 this.currentPageInfo를 사용하고 있는데 이 부분이 제대로 업데이트가 되고 있지 않았다.
이를 해결하기 위해 changePage()에서 this.currentPageInfo 또한 업데이트 해줄 수 있도록 수정하였다.