### PR TITLE
[Feat] 파일로 보드 생성 후 저장하기(덮어쓰기) 시, 보드명 선입력

### DIFF
--- a/src/GridaBoard/Save/PdfDialogTextArea.tsx
+++ b/src/GridaBoard/Save/PdfDialogTextArea.tsx
@@ -1,6 +1,7 @@
 import { DialogContent, makeStyles, TextField } from '@material-ui/core';
 import { LensTwoTone } from '@material-ui/icons';
 import React, { useState } from 'react';
+import { store } from '../client/pages/GridaBoard';
 import getText from "../language/language";
 
 
@@ -23,11 +24,18 @@ const PdfDialogTextArea = (props: Props) => {
   const {saveType, ...rest} = props;
   const classes = useStyles();
   let textRef = null as HTMLElement;
-  const [pdfName, setPdfName] = useState('');
+  const isNewDoc = store.getState().docConfig.isNewDoc;
+  let isNewLoadFileName = "";
+  if(isNewDoc && saveType == "overwrite"){
+    if(store.getState().docConfig.docName !== "undefined"){
+      isNewLoadFileName = store.getState().docConfig.docName;
+    }
+  }
+  const [pdfName, setPdfName] = useState(isNewLoadFileName);
 
   const onChange = (e) => {
     let pdfName = e.target.value;
-    
+
     //이름 설정시 바로 특정 문자만 사용할 수 있도록 수정
     const checkAllow = pdfName.match(/[^a-zA-Z0-9가-힇ㄱ-ㅎㅏ-ㅣぁ-ゔァ-ヴー々〆〤一-龥0-9.+_\-.]/g);
     if(checkAllow !== null){
@@ -37,9 +45,9 @@ const PdfDialogTextArea = (props: Props) => {
     }
 
     setPdfName(pdfName);
-    props.onTextAreaChange(pdfName);
   };
-
+  
+  props.onTextAreaChange(pdfName);
 
   return (
     <DialogContent>


### PR DESCRIPTION
Feat: 파일로 보드 생성 후 저장하기(덮어쓰기) 시, 보드명 선입력
 - 파일로 보드 생성할 시, 타이틀 자동으로 지정되나 다른 이름으로 저장하기, 저장하기(덮어쓰기) 모두 다 공백으로 되어있어, 구분의 필요성이 생기기에 저장하기(덮어쓰기) 시에는 자동으로 지정된 타이틀을 보드명 textField에 선입력되도록 하고, 곧바로 저장 가능하도록 변경