### PR TITLE
[버그] 페이지이동/회전 동작 시 첫번째 thumbnail의 stroke가 잘못 redraw되는 버그 수정

### DIFF
--- a/src/nl-lib/renderer/penview/PenBasedRenderWorker.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderWorker.tsx
@@ -670,7 +670,19 @@ export default class PenBasedRenderWorker extends RenderWorkerBase {
   };
 
   redrawStrokes = (pageInfo: IPageSOBP, isMainView?: boolean) => {
-    if (isSamePage(this.pageInfo, pageInfo) || this.pageInfo === undefined) {
+    const activePageNo = store.getState().activePage.activePageNo;
+    const activePage = GridaDoc.getInstance().getPageAt(activePageNo);
+    const activePageInfo = activePage.pageInfos[0];
+    /**
+     * 현재 문제 this.pageInfo가 undefined로 들아올 때, 아래의 redraw 로직을 타면 첫번째 thumbnail에 직전 작업했던 page의 stroke가 같이 들어감.
+     * 그렇다고 아래의 조건에서 this.pageInfo === undefined를 제외시키면 첫번째 thumbnail stroke의 회전이 제대로 동작하지 않음.
+     * 9c2678e0e3165c42796acabe6b656cededd156d1 커밋 참고
+     * 따라서, this.pageInfo가 undefined로 들어올 때 다른 페이지에서 동작(페이지이동/회전)시 첫번째 썸네일에 stroke가 들어오는 것을 막고,
+     * 첫번째 썸네일 페이지에서 회전시 정상적으로 동작되게 하기 위하여 activePageNo가 0(첫번째 thumbnail)일때만 동작하게 해야함
+     * 추가로, 현재 들어온 pageInfo와 activePageInfo가 같을때만 동작할 수 있도록 조건을 추가(1->0으로 이동시 activePageNo가 0으로 활성화되면서 로직을 타게됨)
+     * 정리: this.pageInfo가 undefined로 들어오면서 작업페이지가 첫번째(0) thumbnail일때만 아래의 로직을 타게 수정하면 된다.
+     */
+    if (isSamePage(this.pageInfo, pageInfo) || (this.pageInfo === undefined && activePageNo === 0 && isSamePage(pageInfo, activePageInfo))) {
       this.removeAllCanvasObject();
       this.resetLocalPathArray();
       this.resetPageDependentData();


### PR DESCRIPTION
문제상황:
1. pdf를 annotation한 뒤 각각 페이지에 stroke를 그린다.
2. 제스처로 페이지 이동시 직전 작업페이지의 stroke가 첫번째 thumbnail 뷰에 redraw 된다.
3. 이러한 문제는 doubleTap stroke를 지우기 위해 redraw로직을 dispatch하는데 이때 pageInfo가 undefined로 들어오면서 발생
4. 정리: pageInfo가 undefined로 들어올 때, 첫번째 thumbnail이 redraw되면서 직전 작업페이지의 stroke를 그려준다.

첫번째 접근방법,
 [redrawStrokes()안에 있는 this.pageInfo === undefined를 제거하면 되지 않을까?]
- 첫번째 thumbnail이 redraw 로직을 타지 않아 stroke가 따로 들어오지는 않으나 첫번째 thumbnail 페이지 회전 시 stokre가 회전하지 않는다.
- 9c2678e0e3165c42796acabe6b656cededd156d1커밋 참고

두번째 접근방법,
 [this.pageInfo === undefined를 가지면서 첫번째 thumbnail에서만 회전할 수 있도록 조건을 추가]
- 즉, undefined로 들어올 때, 작업페이지가 첫번째(0)인 thumbnail인 경우에만 redraw로직을 타게 하면 회전문제 또한 해결된다.
- 따라서, activePageNo가 0이고, redraw로 들어오는 pageInfo가 activePageNo와 같은 0일때만 redraw를 타게 수정한다.