### PR TITLE
[버그] PDF로 생성된 보드에 마우스 스트로크 생성 시 새 페이지 생성되는 문제 수정

### DIFF
--- a/public/nproj/note_3_1013_1.nproj
+++ b/public/nproj/note_3_1013_1.nproj
@@ -3451,7 +3451,7 @@
         <symbol page="12" page_name="013" type="Rectangle" x="269.759" y="258.049" width="24.0678" height="24.0048" lock="1" xylock="0">
             <name></name>
             <id>{992a8e72-1bcc-4049-9be6-b576342eabed}</id>
-            <command name="" action="Custom" param="##FFFFD001"/>
+            <command name="" action="Custom" param="#FFFFD001"/>
             <language_resources>
                 <language resource_country="korean" resource_type="" resource_id=""/>
                 <language resource_country="english" resource_type="" resource_id=""/>

--- a/src/GridaBoard/Load/ConvertFileLoad.tsx
+++ b/src/GridaBoard/Load/ConvertFileLoad.tsx
@@ -124,6 +124,9 @@ const ConvertFileLoad = (props: Props) => {
 
   async function inputChange()
   {
+    const path = `/app`;
+    history.push(path);
+
     const inputer = document.getElementById("fileForconvert") as HTMLInputElement;
     let fullFileName = inputer.files[0].name;
     
@@ -146,7 +149,8 @@ const ConvertFileLoad = (props: Props) => {
     }
 
     if(!(fileType === "pdf" || fileType === "grida")) {
-      if(fullFileName[0] === "." || fullFileName.search(/[^a-zA-Z0-9가-힇ㄱ-ㅎㅏ-ㅣぁ-ゔァ-ヴー々〆〤一-龥0-9.+_\- .]/g) !== -1){
+      if(inputer.files[0].name[0] === "." || fullFileName.search(/[^a-zA-Z0-9가-힇ㄱ-ㅎㅏ-ㅣぁ-ゔァ-ヴー々〆〤一-龥0-9.+_\- .]/g) !== -1){
+        history.replace(`/list`);
         alert(getText("alert_wrongFileName"));
         return;
       }
@@ -171,10 +175,6 @@ const ConvertFileLoad = (props: Props) => {
     }else{
       doFileConvert(inputer);
     }
-    
-    const path = `/app`;
-    history.push(path);
-
   }
 
   async function doFileConvert(inputer: HTMLInputElement){


### PR DESCRIPTION
Fix: PDF로 생성된 보드에 마우스 스트로크 생성 시 새 페이지 생성되는 문제 수정
 - /list 파일로 보드 생성을 PDF로 할 경우, 해당 보드에서 마우스로 첫 스트로크 그릴 시 PDF 페이지가 아닌,
   새 페이지 자동 생성 후, 해당 페이지에 첫 스트로크가 그려지는 이슈
 - 파일로 보드 생성을 PDF로 할 경우, 로딩 서클이 생성되지 않는 이슈
 - history path 코드를 최상단으로 옮기고, 잘못된 파일 불러올 경우에는 해당 페이지 이동을 /list 페이지로 대체하여 이동 방지

 - 기타 사항으로, 파일명이 ' . ' 으로 시작하는 경우 수정

Fix: PUI 색상 데이터 수정
 - 중복된 # 제거