### PR TITLE
Fix: 07f3642 커밋 수정으로 인한 activePage가 undefined일 때 발생하는 버그 수정

### DIFF
--- a/src/nl-lib/renderer/penview/PenBasedRenderWorker.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderWorker.tsx
@@ -672,6 +672,7 @@ export default class PenBasedRenderWorker extends RenderWorkerBase {
   redrawStrokes = (pageInfo: IPageSOBP, isMainView?: boolean) => {
     const activePageNo = store.getState().activePage.activePageNo;
     const activePage = GridaDoc.getInstance().getPageAt(activePageNo);
+    if (!activePage) return;
     const activePageInfo = activePage.pageInfos[0];
     /**
      * 현재 문제 this.pageInfo가 undefined로 들아올 때, 아래의 redraw 로직을 타면 첫번째 thumbnail에 직전 작업했던 page의 stroke가 같이 들어감.


### PR DESCRIPTION
문제상황:
전체 페이지가 줄었을때(페이지가 삭제되었을때) redraw가 발생하는 데(* PenBaseRenderer.tsx -> shouldComponentUpdate 358번째 줄) 이때 페이지가 1개 존재하다가 삭제되면 activePage는 undefined가 되기 때문에 이 후의 로직을 진행하면 오류페이지가 발생한다.

따라서, 이를 해결하기 위해 activePage가 존재하지 않을 경우 redraw를 종료시켜준다.
