### PR TITLE
[버그] 보드 리스트 정렬 방식 변경 시 썸네일 미갱신 수정

### DIFF
--- a/src/boardList/layout/component/mainContent/GridView.tsx
+++ b/src/boardList/layout/component/mainContent/GridView.tsx
@@ -124,7 +124,7 @@ const GridView = (props: Props) => {
   
   useEffect(()=>{
     getData();
-  },[]); 
+  },[docsList]); 
   useEffect(() => {
     //초기화 
     setPathList([]);


### PR DESCRIPTION
Fix: 보드 리스트 정렬 방식 변경 시 썸네일 미갱신 수정 