### PR TITLE
[심볼] 회전시 심볼이 표시되는 조건 변경

### DIFF
--- a/src/GridaBoard/components/buttons/RotateButton.tsx
+++ b/src/GridaBoard/components/buttons/RotateButton.tsx
@@ -9,6 +9,7 @@ import { RotateRight } from "@material-ui/icons";
 import SimpleTooltip2 from "../SimpleTooltip2";
 import getText from 'GridaBoard/language/language';
 import { store } from "GridaBoard/client/pages/GridaBoard";
+import { setNotFirstPenDown } from "../../store/reducers/gestureReducer";
 
 export const onToggleRotate = () => {
   const activePageNo = store.getState().activePage.activePageNo;
@@ -18,6 +19,7 @@ export const onToggleRotate = () => {
   if(activePageNo === -1) return ;
 
   setRotationTrigger(!rotationTrigger);
+  setNotFirstPenDown(false);
 
   const page = doc.getPageAt(activePageNo);
 

--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -582,25 +582,28 @@ class PenBasedRenderer extends React.Component<Props, State> {
   onLivePenPageInfo = (event: IPenToViewerEvent) => {
     const { section, owner, book, page } = event;
     const prevPageInfo = this.props.pageInfo;
+    let isRun = true;
+
     if (isSamePage(prevPageInfo, event as IPageSOBP) && (!this.shouldSendPageInfo)) {
-      return;
+      isRun = false;
     }
     this.shouldSendPageInfo = false;
 
     if (this.props.calibrationMode) {
-      return;
+      isRun = false;
     }
     if (isPUI(event as IPageSOBP)) {
-      return;
+      isRun = false;
     }
     /** pdf pageNo를 바꿀 수 있게, container에게 전달한다. */
-    if (this.props.onNcodePageChanged) {
+    if (isRun && this.props.onNcodePageChanged) {
       this.renderer.registerPageInfoForPlate(event);//hover page info를 거치지 않고 바로 page info로 들어오는 경우(빨리 찍으면 hover 안들어옴)
       this.props.onNcodePageChanged({ section, owner, book, page });
-      // (페이지가 refresh 되고) 부기보드를 첫 터치했을때 심볼이 보여지도록 한다. 
-      if (isSamePage(this.props.pageInfo, PlateNcode_3) && !this.props.notFirstPenDown) {
-        this.onSymbolUp();
-      }
+    }
+
+    // (페이지가 refresh 되고) 부기보드를 첫 터치했을때 심볼이 보여지도록 한다. 추가, 회전 후 부기보드를 첫 터치할 때 심볼이 보여지도록 한다.
+    if (isSamePage(this.props.pageInfo, PlateNcode_3) && !this.props.notFirstPenDown) {
+      this.onSymbolUp();
     }
   }
 
@@ -725,7 +728,6 @@ class PenBasedRenderer extends React.Component<Props, State> {
 
   /** Left Control Zone - Rotate */
   leftControlZone = () => {
-    this.onSymbolUp();
     onToggleRotate();
   }
 


### PR DESCRIPTION
기존내용에서 수정내용으로 회전 시 심볼 표시 조건을 변경하였습니다.

기존내용: 
부기보드 내에서 제스처로 회전을 할 시 무조건 화면에 심볼이 나타나도록 한다.

수정내용:
회전을 한 뒤 부기보드를 터치하면 심볼이 나타나도록 한다. * 한번만 허용