### PR TITLE
[Feat] 그룹 카테고리 변화 시 MainContent에 즉각 반영, 보드 이동 Dialog 텍스트 수정

### DIFF
--- a/src/boardList/BoardList.tsx
+++ b/src/boardList/BoardList.tsx
@@ -75,6 +75,7 @@ const BoardList = () => {
   const isShowDialog = useSelector((state: RootState) => state.list.dialog.show);
   const isShowDropdown = useSelector((state: RootState) => state.list.dropDown.show);
   const isCategoryChange = useSelector((state: RootState) => state.list.isChange.group);
+  const selectedCategory = useSelector((state: RootState) => state.list.dialog.selected);
   
   const categoryChange = async ()=>{
     const dataArr = await getCategoryArray();
@@ -86,11 +87,17 @@ const BoardList = () => {
     if(!isNaN(Number(category)) && Number(category) >= dataArr.length){
       setCategory((dataArr.length-1).toString());
     }
-
+    if(selectedCategory){
+      if(!isNaN(Number(selectedCategory[3])) && dataArr[selectedCategory[3]][1] === -1){
+        setCategory("0");
+      }
+    }
+    
     setDocsObj({
       ...docsObj,
       category: dataArr,
     });
+    dispatch(forceUpdateBoardList());
   }
   
   useEffect(()=>{

--- a/src/boardList/layout/component/dialog/detail/MoveDialog.tsx
+++ b/src/boardList/layout/component/dialog/detail/MoveDialog.tsx
@@ -324,7 +324,10 @@ const MoveDialog = (props: Props)=>{
       {categoryData.map((el,idx)=>{
         return (<div key={idx} onClick={e=>selectCategory(idx)} className={`${moveClasses.contentItems} ${idx === nowSelect ? moveClasses.selectedItem: ""}`}>
             <div>
-              {el[0] === "Unshelved" ? getText("boardList_unshelved").substring(0,5) : el[0]}{` (${el[2]})`}
+              {el[0] === "Unshelved" ?
+                getText("boardList_unshelved").replace("%d", el[2]) :
+                el[0] + ` (${el[2]})`
+              }
             </div>
             { nowSelect === idx ? 
             <SvgIcon>

--- a/src/boardList/layout/component/dialog/detail/MoveDialog.tsx
+++ b/src/boardList/layout/component/dialog/detail/MoveDialog.tsx
@@ -324,7 +324,7 @@ const MoveDialog = (props: Props)=>{
       {categoryData.map((el,idx)=>{
         return (<div key={idx} onClick={e=>selectCategory(idx)} className={`${moveClasses.contentItems} ${idx === nowSelect ? moveClasses.selectedItem: ""}`}>
             <div>
-              {el[0]}{` (${el[2]})`}
+              {el[0] === "Unshelved" ? getText("boardList_unshelved").substring(0,5) : el[0]}{` (${el[2]})`}
             </div>
             { nowSelect === idx ? 
             <SvgIcon>


### PR DESCRIPTION
Feat: 그룹 삭제 등 카테고리 변화 시 변경사항 MainContent에 미반영 수정
 - 그룹 삭제, 그룹 이름 변경 등 카테고리 변화가 발생할 경우 MainContent에 반영되도록 updateCount 추가 변경
 - 그룹 삭제 시, 해당 그룹 내 보드들이 기본 그룹으로 이동하는 것을 바로 인지할 수 있도록, 기본 그룹 으로 카테고리 이동

Feat: 보드 이동 dialog 상 Unshelved 표시 수정
 - 선택한 보드의 그룹 이동 시의 dialog 상에 기본 그룹이 Unshelved로 표시되는 부분 수정