### PR TITLE
Feat: 포커스 이동과 무관하게 scrollToThumbnail 함수 수행 보장

### DIFF
--- a/src/GridaBoard/KeyBoardShortCut.ts
+++ b/src/GridaBoard/KeyBoardShortCut.ts
@@ -201,7 +201,7 @@ export default function KeyBoardShortCut(evt: KeyboardEvent) {
           return;
         }
         setActivePageNo(activePageNo-1);
-        scrollToThumbnail(activePageNo-1);
+        scrollToThumbnail(activePageNo-1, evt);
         break;
       }
       // page down
@@ -217,7 +217,7 @@ export default function KeyBoardShortCut(evt: KeyboardEvent) {
           return;
         }
         setActivePageNo(activePageNo+1);
-        scrollToThumbnail(activePageNo+1);
+        scrollToThumbnail(activePageNo+1, evt);
         break;
       }
 

--- a/src/nl-lib/common/util/functions.ts
+++ b/src/nl-lib/common/util/functions.ts
@@ -463,7 +463,10 @@ export function scrollToBottom(id: string) {
   // (ele) ? ele.scrollTo(0, ele.scrollHeight) : null;
 }
 
-export function scrollToThumbnail(pageNo : Number){
+export function scrollToThumbnail(pageNo: Number, event?: KeyboardEvent){
+  if(event){
+    event.preventDefault();
+  }
   const ele = document.getElementById("thumbnail - " + pageNo + " -mixed_view");
   (ele) ? ele.scrollIntoView({behavior: "smooth", block: "center"}) : null;
 }


### PR DESCRIPTION
Feat: 포커스 이동에 따른 썸네일 이동 함수 보장
 - 마우스로 보드나 썸네일을 클릭하여 해당 영역의 스크롤이 활성화 상태가 될 경우,
    키보드 클릭에 따른 scrollIntoView의 스크롤 제어권을 잃게 되므로 preventDefault 추가