### PR TITLE
[심볼/버그] 심볼이 항상 보여지도록 수정, 플레이트<->종이 사용시 hoverPoint 맞지 않는 버그

### DIFF
--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -404,7 +404,7 @@ class PenBasedRenderer extends React.Component<Props, State> {
       this.pdfSize = { ...nextProps.pdfSize, scale: this.pdfSize.scale };
 
       //회전 후 symbol(toast포함)의 display 상태 초기화(안보이도록 처리)
-      this.onSymbolDown();
+      hideToastMessage();
       ret_val = true;
     }
 
@@ -458,7 +458,7 @@ class PenBasedRenderer extends React.Component<Props, State> {
         this.props.setNotFirstPenDown(false);
         this.props.initializeCrossLine();
         this.props.initializeTap();
-        this.onSymbolDown();
+        hideToastMessage();
       }
 
       if (this.props.calibrationMode) {
@@ -622,7 +622,7 @@ class PenBasedRenderer extends React.Component<Props, State> {
       this.renderer.registerPageInfoForPlate(event);//hover page info를 거치지 않고 바로 page info로 들어오는 경우(빨리 찍으면 hover 안들어옴)
       this.props.onNcodePageChanged({ section, owner, book, page });
       //Plate <-> NcodePage 변화에서의 symbol(toast포함)의 display 상태 초기화(안보이도록 처리)
-      this.onSymbolDown();
+      hideToastMessage();
     }
 
     // (페이지가 refresh 되고) 부기보드를 첫 터치했을때 심볼이 보여지도록 한다. 추가, 회전 후 부기보드를 첫 터치할 때 심볼이 보여지도록 한다.
@@ -1157,13 +1157,13 @@ class PenBasedRenderer extends React.Component<Props, State> {
   }
 
   onSymbolUp = () => {
-    clearTimeout(this.symbolTimer);
+    // clearTimeout(this.symbolTimer);
     this.props.setNotFirstPenDown(true);
     showMessageToast(getText('check_symbol_position'));
-    this.props.showSymbol();
-    this.symbolTimer = setTimeout(function() {
-      hideSymbol();
-    }, 10000);
+    // this.props.showSymbol();
+    // this.symbolTimer = setTimeout(function() {
+    //   hideSymbol();
+    // }, 10000);
   }
 
   onSymbolDown = () => {
@@ -1207,7 +1207,7 @@ class PenBasedRenderer extends React.Component<Props, State> {
       fontSize: "32px",
       color: theme.palette.error.main,
       opacity: 0.5,
-      visibility: this.props.show && this.props.isMainView ? 'visible' : 'hidden'
+      visibility: this.props.isMainView ? 'visible' : 'hidden'
     }
 
     const shadowStyle: CSSProperties = {


### PR DESCRIPTION
기존내용에서 수정내용으로 심볼 display 로직을 수정함.

기존내용: 
 페이지 이동/회전과 같은 상태 변화 후 플레이트 첫 터치시 보여질 수 있도록 함

수정내용: 
 조건없이 심볼이 항상 보여질 수 있도록 함

<추가내용>
이후 심볼의 보여지는 조건을 다시 정의할 수 있어 기존의 심볼 timer 및 show/hide 함수는 주석처리 하였습니다.
상태 변화로 연달아 발생하는 toast 메세지는 최신의 메시지 한개만 보여질 수 있도록 기존의 toast 메세지는 사라지도록 수정하였습니다.

------------------------------------------------------
테스트 도중 버그 발견하여 수정 업데이트 합니다. 충돌로 인해 해당 브렌치에 이어서 작업합니다.

발생내용: 플레이트 -> 종이 사용시 (종이 pdf 생성) 종이를 plate로 인식하며 hoverPoint가 맞지 않는 현상

- onLivePenPageInfo() 안에서 isRun 플래그를 사용하는데(심볼 때문에 정의 #428 ) 이로 인해, 
   플레이트 -> Ncode 종이 사용시 registerPageInfoForPlate, onNcodePageChanged 로직을 정상적으로 타지 못함.
   결국 pageInfo를 업데이트 하지 못함.
- isRun은 심볼을 보여주기 위한 조건으로 사용되는 플래그임. 따라서, 해당 플래그 조건을 안쪽으로 옮겨준다.
