### PR TITLE
[심볼] 종이, 플레이트 관계없이 심볼이 항상 뜨는 현상

### DIFF
--- a/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
+++ b/src/nl-lib/renderer/penview/PenBasedRenderer.tsx
@@ -1207,7 +1207,7 @@ class PenBasedRenderer extends React.Component<Props, State> {
       fontSize: "32px",
       color: theme.palette.error.main,
       opacity: 0.5,
-      visibility: this.props.isMainView ? 'visible' : 'hidden'
+      visibility: !this.props.gestureDisable && this.props.isMainView ? 'visible' : 'hidden'
     }
 
     const shadowStyle: CSSProperties = {


### PR DESCRIPTION
조건을 추가하여 플레이트 사용시에만 symbol이 항상 뜨도록 설정합니다.